### PR TITLE
fix: add notify-staging.ippoan.org custom domain for staging

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,9 +10,12 @@
 	"env": {
 		"staging": {
 			"name": "nuxt-notify-staging",
+			"routes": [
+				{ "pattern": "notify-staging.ippoan.org", "custom_domain": true }
+			],
 			"vars": {
 				"NUXT_PUBLIC_API_BASE": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
-				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-worker-staging.m-tama-ramu.workers.dev"
+				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org"
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- staging に `notify-staging.ippoan.org` カスタムドメイン追加
- AUTH_WORKER_URL を auth-staging.ippoan.org に変更

## Test plan
- [ ] notify-staging.ippoan.org でアクセス可能を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)