### PR TITLE
feat: add notify.ippoan.org custom domain

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,12 +11,21 @@
 		"staging": {
 			"name": "nuxt-notify-staging",
 			"routes": [
-				{ "pattern": "notify-staging.ippoan.org", "custom_domain": true }
+				{
+					"pattern": "notify-staging.ippoan.org",
+					"custom_domain": true
+				}
 			],
 			"vars": {
 				"NUXT_PUBLIC_API_BASE": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
 				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org"
 			}
 		}
-	}
+	},
+	"routes": [
+		{
+			"pattern": "notify.ippoan.org",
+			"custom_domain": true
+		}
+	]
 }


### PR DESCRIPTION
本番カスタムドメイン `notify.ippoan.org` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)