### PR TITLE
fix: add production routes and API_BASE for notify.ippoan.org

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,9 +10,12 @@
 	"env": {
 		"staging": {
 			"name": "nuxt-notify-staging",
+			"routes": [
+				{ "pattern": "notify-staging.ippoan.org", "custom_domain": true }
+			],
 			"vars": {
 				"NUXT_PUBLIC_API_BASE": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
-				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-worker-staging.m-tama-ramu.workers.dev"
+				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org"
 			}
 		}
 	}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,13 @@
 	"assets": {
 		"directory": ".output/public"
 	},
+	"routes": [
+		{ "pattern": "notify.ippoan.org", "custom_domain": true }
+	],
+	"vars": {
+		"NUXT_PUBLIC_API_BASE": "https://alc-api.ippoan.org",
+		"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth.ippoan.org"
+	},
 	"env": {
 		"staging": {
 			"name": "nuxt-notify-staging",


### PR DESCRIPTION
## Summary
- 本番環境の `NUXT_PUBLIC_API_BASE` が未設定で `http://localhost:8080` にフォールバックしていた
- `wrangler.jsonc` に本番用 `routes` と `vars` を追加

## Test plan
- [ ] デプロイ後、notify.ippoan.org で DevTools Network タブを確認し、リクエスト先が `https://alc-api.ippoan.org` になっていること
- [ ] `/api/notify/documents?limit=20` が正常にレスポンスを返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)