### PR TITLE
fix: add production vars for notify.ippoan.org

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,6 +22,10 @@
 			}
 		}
 	},
+	"vars": {
+		"NUXT_PUBLIC_API_BASE": "https://alc-api.ippoan.org",
+		"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth.ippoan.org"
+	},
 	"routes": [
 		{
 			"pattern": "notify.ippoan.org",


### PR DESCRIPTION
## Summary
- 本番環境の `NUXT_PUBLIC_API_BASE` が未設定で `http://localhost:8080` にフォールバックしていた
- `wrangler.jsonc` に本番用 `vars` を追加 (`NUXT_PUBLIC_API_BASE`, `NUXT_PUBLIC_AUTH_WORKER_URL`)

## Test plan
- [ ] デプロイ後、notify.ippoan.org で DevTools Network タブを確認し、リクエスト先が `https://alc-api.ippoan.org` になっていること
- [ ] `/api/notify/documents?limit=20` が正常にレスポンスを返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)