### PR TITLE
feat: select recipients in /test-distribute instead of all

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -111,7 +111,7 @@ onMounted(() => {
         </div>
         <p class="text-gray-500 mb-4">ログインしてください</p>
         <div class="flex flex-col items-center gap-3">
-          <button @click="redirectToLogin"
+          <button @click="() => redirectToLogin()"
                   class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 w-56">
             Google でログイン
           </button>

--- a/app/pages/test-distribute.vue
+++ b/app/pages/test-distribute.vue
@@ -1,10 +1,58 @@
 <script setup lang="ts">
 const { apiFetch } = useApi()
 
+interface Recipient {
+  id: string
+  name: string
+  provider: 'line' | 'lineworks'
+  lineworks_user_id: string | null
+  line_user_id: string | null
+  phone_number: string | null
+  email: string | null
+  enabled: boolean
+}
+
 const message = ref('📨 テスト配信メッセージです。\n\nこのメッセージが届いていれば配信システムは正常に動作しています。')
 const sending = ref(false)
 const result = ref<{ sent: number; failed: number; total: number } | null>(null)
 const error = ref('')
+
+const recipients = ref<Recipient[]>([])
+const loading = ref(true)
+const loadError = ref('')
+const selected = ref<Set<string>>(new Set())
+
+const enabledRecipients = computed(() => recipients.value.filter(r => r.enabled))
+
+async function loadRecipients() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    recipients.value = await apiFetch('/notify/recipients')
+  } catch (e: any) {
+    loadError.value = e.message || String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function toggle(id: string) {
+  const next = new Set(selected.value)
+  if (next.has(id)) {
+    next.delete(id)
+  } else {
+    next.add(id)
+  }
+  selected.value = next
+}
+
+function selectAll() {
+  selected.value = new Set(enabledRecipients.value.map(r => r.id))
+}
+
+function clearAll() {
+  selected.value = new Set()
+}
 
 async function send() {
   sending.value = true
@@ -13,7 +61,10 @@ async function send() {
   try {
     result.value = await apiFetch('/notify/test-distribute', {
       method: 'POST',
-      body: JSON.stringify({ message: message.value }),
+      body: JSON.stringify({
+        message: message.value,
+        recipient_ids: [...selected.value],
+      }),
     })
   } catch (e: any) {
     error.value = e.message || String(e)
@@ -21,13 +72,15 @@ async function send() {
     sending.value = false
   }
 }
+
+onMounted(loadRecipients)
 </script>
 
 <template>
   <div>
     <h2 class="text-xl font-bold mb-4">テスト配信</h2>
     <p class="text-sm text-gray-500 mb-4">
-      登録済みの全受信者（有効）にテストメッセージを送信します。
+      選択した受信者にテストメッセージを送信します。
     </p>
 
     <div class="bg-white rounded-lg shadow p-4 border mb-4">
@@ -35,15 +88,61 @@ async function send() {
       <textarea v-model="message" rows="5"
                 class="w-full border rounded px-3 py-2 text-sm font-mono"
                 placeholder="配信するメッセージを入力..." />
-
-      <button @click="send" :disabled="sending || !message.trim()"
-              class="mt-3 bg-blue-600 text-white px-6 py-2 rounded text-sm hover:bg-blue-700 disabled:opacity-50">
-        {{ sending ? '送信中...' : '🚀 テスト送信' }}
-      </button>
     </div>
 
+    <div class="bg-white rounded-lg shadow p-4 border mb-4">
+      <div class="flex items-center justify-between mb-3">
+        <label class="text-sm font-medium text-gray-700">送信先</label>
+        <div class="flex items-center gap-2 text-sm">
+          <span class="text-gray-500">
+            {{ selected.size }} / {{ enabledRecipients.length }} 人 選択中
+          </span>
+          <button @click="selectAll" type="button"
+                  :disabled="enabledRecipients.length === 0"
+                  class="px-2 py-1 text-xs border rounded hover:bg-gray-50 disabled:opacity-50">
+            全選択
+          </button>
+          <button @click="clearAll" type="button"
+                  :disabled="selected.size === 0"
+                  class="px-2 py-1 text-xs border rounded hover:bg-gray-50 disabled:opacity-50">
+            全解除
+          </button>
+        </div>
+      </div>
+
+      <div v-if="loading" class="text-sm text-gray-500 py-4 text-center">
+        受信者を読み込み中...
+      </div>
+      <div v-else-if="loadError" class="bg-red-50 border border-red-200 rounded p-3 text-red-700 text-sm">
+        {{ loadError }}
+      </div>
+      <div v-else-if="enabledRecipients.length === 0" class="text-sm text-gray-500 py-4 text-center">
+        有効な受信者がいません。<NuxtLink to="/recipients" class="text-blue-600 hover:underline">受信者管理</NuxtLink>から登録してください。
+      </div>
+      <ul v-else class="divide-y border rounded">
+        <li v-for="r in enabledRecipients" :key="r.id"
+            class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+            @click="toggle(r.id)">
+          <input type="checkbox" :checked="selected.has(r.id)"
+                 @click.stop="toggle(r.id)"
+                 class="w-4 h-4" />
+          <span class="flex-1 text-sm">{{ r.name }}</span>
+          <span :class="r.provider === 'line' ? 'text-green-600' : 'text-blue-600'"
+                class="text-xs font-medium">
+            {{ r.provider === 'line' ? 'LINE' : 'LINE WORKS' }}
+          </span>
+        </li>
+      </ul>
+    </div>
+
+    <button @click="send"
+            :disabled="sending || !message.trim() || selected.size === 0"
+            class="bg-blue-600 text-white px-6 py-2 rounded text-sm hover:bg-blue-700 disabled:opacity-50">
+      {{ sending ? '送信中...' : `🚀 テスト送信 (${selected.size} 人)` }}
+    </button>
+
     <!-- 結果 -->
-    <div v-if="result" class="bg-white rounded-lg shadow p-4 border">
+    <div v-if="result" class="bg-white rounded-lg shadow p-4 border mt-4">
       <h3 class="font-bold mb-2">送信結果</h3>
       <div class="grid grid-cols-3 gap-4 text-center">
         <div>

--- a/tests/integration/notify-api.test.ts
+++ b/tests/integration/notify-api.test.ts
@@ -95,22 +95,41 @@ describe.skipIf(skip)('notify API integration', () => {
   })
 
   // --- Test Distribute ---
-  it('POST /notify/test-distribute — with no active recipients', async () => {
+  it('POST /notify/test-distribute — empty recipient_ids returns 400', async () => {
+    const { status } = await api('/notify/test-distribute', {
+      method: 'POST',
+      body: { message: 'Integration test message', recipient_ids: [] },
+    })
+    expect(status).toBe(400)
+  })
+
+  it('POST /notify/test-distribute — with selected recipient_ids', async () => {
     // Clean up any test recipients
-    const { data: recipients } = await api('/notify/recipients')
-    for (const r of recipients as any[]) {
+    const { data: existing } = await api('/notify/recipients')
+    for (const r of existing as any[]) {
       if (r.name.includes('Integration Test')) {
         await api(`/notify/recipients/${r.id}`, { method: 'DELETE' })
       }
     }
 
+    // Get one enabled recipient id to target
+    const { data: recipients } = await api('/notify/recipients')
+    const target = (recipients as any[]).find((r) => r.enabled)
+    const recipient_ids = target ? [target.id] : []
+
+    if (recipient_ids.length === 0) {
+      // No enabled recipient available in this env — skip the 200 path
+      return
+    }
+
     const { status, data } = await api('/notify/test-distribute', {
       method: 'POST',
-      body: { message: 'Integration test message' },
+      body: { message: 'Integration test message', recipient_ids },
     })
     expect(status).toBe(200)
-    // seed recipients exist but have no real LINE/LW credentials → failed or sent=0
+    // seed recipients have no real LINE/LW credentials → failed or sent=0
     expect(typeof data.total).toBe('number')
+    expect(data.total).toBeLessThanOrEqual(recipient_ids.length)
   })
 
   // --- Read Tracker ---


### PR DESCRIPTION
Adds a checkbox list of enabled recipients on the `/test-distribute` page. The API call now sends `recipient_ids: [...selected]`. Send button is disabled when nothing is selected. Select-all / clear-all helpers provided for convenience.

## UI changes

- Fetches `/notify/recipients` on mount, filters to `enabled === true`
- Checkbox list with clickable rows + provider badge (LINE / LINE WORKS)
- Selected count shown: `N / M 人 選択中`
- Send button shows count: `🚀 テスト送信 (N 人)`
- Description changed from "登録済みの全受信者(有効)に..." → "選択した受信者に..."

## Integration test

Split into two cases:
- Empty `recipient_ids` → expect 400
- Selected 1 enabled recipient → expect 200, total ≤ 1

## Backend

Requires rust-alc-api PR #264 (`feat(notify): accept recipient_ids in test-distribute`).