### PR TITLE
fix: wrap redirectToLogin in arrow fn for click handler type

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -111,7 +111,7 @@ onMounted(() => {
         </div>
         <p class="text-gray-500 mb-4">ログインしてください</p>
         <div class="flex flex-col items-center gap-3">
-          <button @click="redirectToLogin"
+          <button @click="() => redirectToLogin()"
                   class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 w-56">
             Google でログイン
           </button>


### PR DESCRIPTION
`auth-client`'s `redirectToLogin` takes an `options` arg, which clashes with Vue's `@click` handler signature (`PointerEvent`) under strict typecheck. Wrap in an arrow fn so Vue doesn't pass the event.

Currently blocking PR #24.