### PR TITLE
feat: replace logout button with AuthToolbar in header

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { useAuth } from '@ippoan/auth-client'
+import { useAuth, AuthToolbar } from '@ippoan/auth-client'
 
-const { isAuthenticated, loadFromStorage, consumeFragment, redirectToLogin, logout } = useAuth()
+const { isAuthenticated, loadFromStorage, consumeFragment, redirectToLogin } = useAuth()
 const runtimeConfig = useRuntimeConfig()
 const { apiFetch } = useApi()
 
@@ -82,10 +82,18 @@ onMounted(() => {
             <NuxtLink to="/" class="text-gray-600 hover:text-blue-600">ダッシュボード</NuxtLink>
             <NuxtLink to="/recipients" class="text-gray-600 hover:text-blue-600">受信者</NuxtLink>
             <NuxtLink to="/test-distribute" class="text-gray-600 hover:text-blue-600">テスト配信</NuxtLink>
-            <NuxtLink to="/settings" class="text-gray-600 hover:text-blue-600">設定</NuxtLink>
+            <NuxtLink to="/settings" class="text-gray-600 hover:text-blue-600">配信設定</NuxtLink>
           </nav>
-          <button v-if="isAuthenticated" @click="logout"
-                  class="text-xs text-gray-400 hover:text-red-500">ログアウト</button>
+          <AuthToolbar
+            v-if="isAuthenticated"
+            :show-copy-url="false"
+            :show-qr="false"
+            :show-apps="true"
+            :show-settings="true"
+            :show-logout="true"
+            :show-user-info="true"
+            :show-org-slug="true"
+          />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- ヘッダーの自作ログアウトボタンを @ippoan/auth-client の AuthToolbar に置き換え
- AuthToolbar は組織スラッグ・ユーザー名・provider バッジ・Apps・設定・Logout を表示 (showCopyUrl/showQr は無効)
- ラベル衝突回避のため独自ナビ \`設定\` → \`配信設定\` にリネーム (AuthToolbar の「設定」は auth-worker /settings に飛ぶ別物)

## Test plan
- [x] /wt-quick で tunnel 起動、ヘッダー右側に AuthToolbar が表示されること確認
- [x] 独自ナビが \`ダッシュボード / 受信者 / テスト配信 / 配信設定\` の4つになること
- [ ] Logout で auth-worker /login にリダイレクトされること
- [ ] マルチ組織アカウントで組織切替メニューが動作すること