### PR TITLE
fix(lineworks): point webhookUrl to auth-worker

### DIFF
--- a/app/pages/lineworks-groups.vue
+++ b/app/pages/lineworks-groups.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const { apiFetch } = useApi()
 const config = useRuntimeConfig()
-const apiBase = config.public.apiBase as string
+const authWorkerUrl = config.public.authWorkerUrl as string
 
 interface LineworksChannel {
   id: string
@@ -83,7 +83,9 @@ function formatDate(iso: string): string {
 }
 
 function webhookUrl(botId: string): string {
-  return `${apiBase}/api/notify/lineworks/webhook/${botId}`
+  // LINE WORKS callback は auth-worker (Cloudflare Workers) で受ける。
+  // edge で HMAC 検証 + Durable Object に enqueue → backend へ転送する。
+  return `${authWorkerUrl}/lineworks/webhook/${botId}`
 }
 
 async function copyText(text: string) {


### PR DESCRIPTION
## Summary

LINE WORKS callback URL の表示先を rust-alc-api (Cloud Run) から auth-worker (Cloudflare Workers) に切り替える。これは LINE WORKS callback 移設プロジェクトの **Step 4**: ユーザーが Bot 編集 UI でコピーして LINE WORKS Developers Console に貼る Callback URL を新エンドポイントに合わせる。

関連 PR:
- ippoan/rust-alc-api#289 (Step 1: backend に internal route 追加)
- ippoan/auth-worker#83 (Step 2: auth-worker に Durable Object 経由の webhook handler)

## 変更内容

\`app/pages/lineworks-groups.vue\` の \`webhookUrl()\`:
\`\`\`diff
- return \`\${apiBase}/api/notify/lineworks/webhook/\${botId}\`
+ return \`\${authWorkerUrl}/lineworks/webhook/\${botId}\`
\`\`\`

\`NUXT_PUBLIC_AUTH_WORKER_URL\` は既に wrangler.jsonc の prod / staging 両方で設定済みなので追加環境変数は不要。

## 注意

このフロントエンドは「ユーザーが LINE WORKS Developers Console に貼る URL を表示するだけ」なので、本 PR がマージされても LINE WORKS の callback が即切替わるわけではない。実際の切替は **Step 5** で LINE WORKS Developers Console を手動操作して行う (各 bot ごとに既存 URL を auth-worker URL に書き換える)。本 PR は Step 5 のときに表示が正しく出るようにする準備。

## Test plan

- [ ] CI: vitest + typecheck
- [ ] staging deploy 後に notify-staging.ippoan.org の /lineworks-groups で URL 表示確認
- [ ] 表示された URL が \`https://auth-staging.ippoan.org/lineworks/webhook/{bot_id}\` 形式