### PR TITLE
feat(emails): add email inbox UI + ingest_keys management

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -80,6 +80,7 @@ onMounted(() => {
         <div class="flex items-center gap-4">
           <nav v-if="isAuthenticated" class="flex gap-4 text-sm">
             <NuxtLink to="/" class="text-gray-600 hover:text-blue-600">ダッシュボード</NuxtLink>
+            <NuxtLink to="/emails" class="text-gray-600 hover:text-blue-600">受信メール</NuxtLink>
             <NuxtLink to="/recipients" class="text-gray-600 hover:text-blue-600">受信者</NuxtLink>
             <NuxtLink to="/lineworks-groups" class="text-gray-600 hover:text-blue-600">グループ</NuxtLink>
             <NuxtLink to="/test-distribute" class="text-gray-600 hover:text-blue-600">テスト配信</NuxtLink>

--- a/app/pages/emails/[id].vue
+++ b/app/pages/emails/[id].vue
@@ -1,0 +1,257 @@
+<script setup lang="ts">
+import { useAuth } from '@ippoan/auth-client'
+
+const route = useRoute()
+const router = useRouter()
+const { apiFetch } = useApi()
+const { token, orgId } = useAuth()
+
+const messageId = computed(() => String(route.params.id))
+
+interface EmailDocument {
+  id: string
+  file_name: string | null
+  file_size_bytes: number | null
+  r2_key: string
+  extraction_status: string
+  distribution_status: string
+  created_at: string
+}
+
+interface EmailDetail {
+  email_message_id: string
+  source_sender: string | null
+  source_subject: string | null
+  source_body_text: string | null
+  source_received_at: string | null
+  documents: EmailDocument[]
+}
+
+interface Delivery {
+  id: string
+  recipient_id: string
+  recipient_name: string
+  provider: string
+  status: string
+  sent_at: string | null
+  read_at: string | null
+  triggered_by_user_id: string | null
+  triggered_by_name: string | null
+  triggered_by_email: string | null
+  created_at: string
+}
+
+interface DocumentResponse {
+  document: { id: string; file_name?: string | null; distribution_status: string }
+  deliveries: Delivery[]
+}
+
+const detail = ref<EmailDetail | null>(null)
+const deliveriesByDoc = ref<Record<string, Delivery[]>>({})
+const loading = ref(true)
+const error = ref('')
+const distributing = ref<Record<string, boolean>>({})
+const deleting = ref<Record<string, boolean>>({})
+
+async function loadDetail() {
+  loading.value = true
+  error.value = ''
+  try {
+    detail.value = await apiFetch<EmailDetail>(`/notify/emails/${messageId.value}`)
+    await Promise.all(detail.value.documents.map(loadDeliveries))
+  } catch (e: any) {
+    error.value = e.message || String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadDeliveries(doc: EmailDocument) {
+  try {
+    const res = await apiFetch<DocumentResponse>(`/notify/documents/${doc.id}`)
+    deliveriesByDoc.value[doc.id] = res.deliveries
+  } catch {
+    deliveriesByDoc.value[doc.id] = []
+  }
+}
+
+async function downloadDoc(doc: EmailDocument) {
+  try {
+    const config = useRuntimeConfig()
+    const apiBase = config.public.apiBase as string
+    const headers: Record<string, string> = {}
+    if (token.value) {
+      headers.Authorization = `Bearer ${token.value}`
+    } else if (orgId.value) {
+      headers['X-Tenant-ID'] = orgId.value
+    }
+    const res = await fetch(`${apiBase}/api/notify/documents/${doc.id}/download`, { headers })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = doc.file_name ?? 'attachment'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  } catch (e: any) {
+    alert(`ダウンロード失敗: ${e.message ?? e}`)
+  }
+}
+
+async function distribute(doc: EmailDocument) {
+  if (!confirm(`「${doc.file_name ?? 'ドキュメント'}」を全受信者に配信しますか?`)) return
+  distributing.value[doc.id] = true
+  try {
+    await apiFetch(`/notify/documents/${doc.id}/distribute`, {
+      method: 'POST',
+      body: JSON.stringify({ target: { all: true } }),
+    })
+    await loadDetail()
+  } catch (e: any) {
+    alert(`配信失敗: ${e.message ?? e}`)
+  } finally {
+    distributing.value[doc.id] = false
+  }
+}
+
+async function deleteDoc(doc: EmailDocument) {
+  if (!confirm(`「${doc.file_name ?? 'ドキュメント'}」を削除しますか? (R2 + DB から削除)`)) return
+  deleting.value[doc.id] = true
+  try {
+    await apiFetch(`/notify/documents/${doc.id}`, { method: 'DELETE' })
+    await loadDetail()
+    if (!detail.value || detail.value.documents.length === 0) {
+      router.push('/emails')
+    }
+  } catch (e: any) {
+    alert(`削除失敗: ${e.message ?? e}`)
+  } finally {
+    deleting.value[doc.id] = false
+  }
+}
+
+function formatSize(bytes: number | null): string {
+  if (!bytes) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function formatDate(s: string | null): string {
+  if (!s) return '-'
+  return new Date(s).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function deliveryStatusLabel(status: string): { label: string; cls: string } {
+  switch (status) {
+    case 'sent':
+      return { label: '送信済', cls: 'bg-green-100 text-green-700' }
+    case 'failed':
+      return { label: '失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return { label: '未送信', cls: 'bg-gray-100 text-gray-700' }
+    default:
+      return { label: status, cls: 'bg-gray-100 text-gray-700' }
+  }
+}
+
+onMounted(loadDetail)
+</script>
+
+<template>
+  <div>
+    <div class="mb-4">
+      <NuxtLink to="/emails" class="text-sm text-blue-600 hover:underline">← 受信メール一覧</NuxtLink>
+    </div>
+
+    <div v-if="loading" class="text-gray-500 py-10 text-center">読み込み中...</div>
+    <div v-else-if="error" class="bg-red-50 border border-red-200 text-red-700 p-3 rounded">
+      {{ error }}
+    </div>
+    <div v-else-if="detail">
+      <!-- メタデータ -->
+      <div class="bg-white border rounded p-4 mb-6">
+        <h2 class="text-lg font-bold mb-2">{{ detail.source_subject ?? '(件名なし)' }}</h2>
+        <dl class="text-sm grid grid-cols-[6rem_1fr] gap-y-1 text-gray-700">
+          <dt class="text-gray-500">送信者:</dt>
+          <dd>{{ detail.source_sender ?? '-' }}</dd>
+          <dt class="text-gray-500">受信日時:</dt>
+          <dd>{{ formatDate(detail.source_received_at) }}</dd>
+        </dl>
+        <details v-if="detail.source_body_text" class="mt-3">
+          <summary class="text-sm text-gray-500 cursor-pointer">本文を表示</summary>
+          <pre class="mt-2 bg-gray-50 p-2 rounded text-xs whitespace-pre-wrap max-h-64 overflow-auto">{{ detail.source_body_text }}</pre>
+        </details>
+      </div>
+
+      <!-- 添付ファイル -->
+      <h3 class="text-md font-bold mb-2">添付ファイル ({{ detail.documents.length }})</h3>
+      <div v-for="doc in detail.documents" :key="doc.id"
+           class="bg-white border rounded p-4 mb-3">
+        <div class="flex items-center justify-between mb-2">
+          <div>
+            <div class="font-medium">{{ doc.file_name ?? '(無名)' }}</div>
+            <div class="text-xs text-gray-500">{{ formatSize(doc.file_size_bytes) }} · 受信 {{ formatDate(doc.created_at) }}</div>
+          </div>
+          <div class="flex gap-2">
+            <button @click="downloadDoc(doc)"
+                    class="text-xs bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded">
+              ダウンロード
+            </button>
+            <button @click="distribute(doc)" :disabled="distributing[doc.id]"
+                    class="text-xs bg-blue-600 text-white hover:bg-blue-700 px-3 py-1 rounded disabled:opacity-50">
+              {{ distributing[doc.id] ? '配信中...' : '配信' }}
+            </button>
+            <button @click="deleteDoc(doc)" :disabled="deleting[doc.id]"
+                    class="text-xs bg-red-50 text-red-600 hover:bg-red-100 px-3 py-1 rounded disabled:opacity-50">
+              削除
+            </button>
+          </div>
+        </div>
+
+        <!-- 配信履歴 -->
+        <div v-if="deliveriesByDoc[doc.id]?.length" class="mt-3 border-t pt-3">
+          <div class="text-xs text-gray-500 mb-2">配信履歴</div>
+          <table class="w-full text-xs">
+            <thead class="text-gray-500">
+              <tr>
+                <th class="text-left py-1">送信日時</th>
+                <th class="text-left py-1">実行者</th>
+                <th class="text-left py-1">受信者</th>
+                <th class="text-left py-1">手段</th>
+                <th class="text-left py-1">状況</th>
+                <th class="text-left py-1">既読</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="d in deliveriesByDoc[doc.id]" :key="d.id" class="border-t">
+                <td class="py-1 text-gray-700">{{ formatDate(d.sent_at ?? d.created_at) }}</td>
+                <td class="py-1 text-gray-700">
+                  {{ d.triggered_by_name || d.triggered_by_email || '-' }}
+                </td>
+                <td class="py-1 text-gray-900">{{ d.recipient_name }}</td>
+                <td class="py-1 text-gray-500">{{ d.provider }}</td>
+                <td class="py-1">
+                  <span :class="['inline-block px-1.5 py-0.5 rounded', deliveryStatusLabel(d.status).cls]">
+                    {{ deliveryStatusLabel(d.status).label }}
+                  </span>
+                </td>
+                <td class="py-1 text-gray-500">{{ d.read_at ? formatDate(d.read_at) : '-' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-else class="text-xs text-gray-400 mt-2">未配信</div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/emails/index.vue
+++ b/app/pages/emails/index.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+const { apiFetch } = useApi()
+
+interface EmailSummary {
+  email_message_id: string
+  source_sender: string | null
+  source_subject: string | null
+  source_received_at: string | null
+  attachment_count: number
+  total_size_bytes: number | null
+  distribution_status: 'pending' | 'in_progress' | 'completed' | 'failed'
+  created_at: string
+}
+
+const emails = ref<EmailSummary[]>([])
+const loading = ref(true)
+const error = ref('')
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    emails.value = await apiFetch<EmailSummary[]>('/notify/emails')
+  } catch (e: any) {
+    error.value = e.message || String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatSize(bytes: number | null): string {
+  if (!bytes) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function formatDate(s: string | null): string {
+  if (!s) return '-'
+  const d = new Date(s)
+  return d.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function statusBadge(status: string): { label: string; cls: string } {
+  switch (status) {
+    case 'completed':
+      return { label: '配信済', cls: 'bg-green-100 text-green-700' }
+    case 'in_progress':
+      return { label: '配信中', cls: 'bg-yellow-100 text-yellow-700' }
+    case 'failed':
+      return { label: '失敗', cls: 'bg-red-100 text-red-700' }
+    default:
+      return { label: '未配信', cls: 'bg-gray-100 text-gray-700' }
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-xl font-bold">受信メール</h2>
+      <button @click="load" class="text-sm text-blue-600 hover:underline">↻ 更新</button>
+    </div>
+
+    <div v-if="loading" class="text-gray-500 py-10 text-center">読み込み中...</div>
+    <div v-else-if="error" class="bg-red-50 border border-red-200 text-red-700 p-3 rounded">
+      {{ error }}
+    </div>
+    <div v-else-if="emails.length === 0" class="text-gray-500 py-10 text-center">
+      受信メールはまだありません。<br>
+      <span class="text-xs">ingest 用アドレスは「設定」ページから確認できます。</span>
+    </div>
+    <table v-else class="min-w-full bg-white border border-gray-200 text-sm">
+      <thead class="bg-gray-50 text-left text-xs text-gray-600 uppercase">
+        <tr>
+          <th class="px-3 py-2">受信日時</th>
+          <th class="px-3 py-2">送信者</th>
+          <th class="px-3 py-2">件名</th>
+          <th class="px-3 py-2 text-right">添付</th>
+          <th class="px-3 py-2 text-right">サイズ</th>
+          <th class="px-3 py-2">配信状況</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y">
+        <tr v-for="m in emails" :key="m.email_message_id"
+            class="hover:bg-gray-50 cursor-pointer"
+            @click="$router.push(`/emails/${m.email_message_id}`)">
+          <td class="px-3 py-2 whitespace-nowrap text-gray-700">
+            {{ formatDate(m.source_received_at ?? m.created_at) }}
+          </td>
+          <td class="px-3 py-2 text-gray-700">{{ m.source_sender ?? '-' }}</td>
+          <td class="px-3 py-2 text-gray-900">{{ m.source_subject ?? '(件名なし)' }}</td>
+          <td class="px-3 py-2 text-right text-gray-700">{{ m.attachment_count }}</td>
+          <td class="px-3 py-2 text-right text-gray-700">{{ formatSize(m.total_size_bytes) }}</td>
+          <td class="px-3 py-2">
+            <span :class="['inline-block px-2 py-0.5 rounded text-xs', statusBadge(m.distribution_status).cls]">
+              {{ statusBadge(m.distribution_status).label }}
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -199,7 +199,90 @@ async function remove() {
   }
 }
 
-onMounted(load)
+// ===== Email 受信設定 (ingest keys) =====
+interface IngestKey {
+  id: string
+  name: string
+  enabled: boolean
+  created_at: string
+}
+const ingestKeys = ref<IngestKey[]>([])
+const ingestKeysLoading = ref(false)
+const newKeyName = ref('')
+const newPlaintextKey = ref<{ id: string; name: string; key: string } | null>(null)
+
+const ingestEmailDomain = computed(() => {
+  // 本番判定: apiBase ホスト名から推定。最終的には API/Cloudflare 設定と整合させる必要あり。
+  if (apiBase.includes('alc-api.ippoan.org')) return 'notify.ippoan.org'
+  return 'notify-staging.ippoan.org'
+})
+
+const tenantSlug = ref<string>('')
+const ingestEmailAddress = computed(() => {
+  if (!tenantSlug.value) return ''
+  return `tenant-${tenantSlug.value}@${ingestEmailDomain.value}`
+})
+
+async function loadIngestKeys() {
+  ingestKeysLoading.value = true
+  try {
+    ingestKeys.value = await apiFetch<IngestKey[]>('/notify/ingest-keys')
+  } catch (e: any) {
+    error.value = 'ingest_keys 取得失敗: ' + (e.message || String(e))
+  } finally {
+    ingestKeysLoading.value = false
+  }
+}
+
+async function loadTenantSlug() {
+  try {
+    const me = await apiFetch<{ tenant?: { slug?: string } }>('/auth/me')
+    tenantSlug.value = me?.tenant?.slug ?? ''
+  } catch {
+    // /auth/me が無いテナントは tenantId をそのまま使う
+    tenantSlug.value = orgId.value ?? ''
+  }
+}
+
+async function createIngestKey() {
+  if (!newKeyName.value.trim()) return
+  try {
+    const res = await apiFetch<{ id: string; name: string; key: string }>(
+      '/notify/ingest-keys',
+      { method: 'POST', body: JSON.stringify({ name: newKeyName.value.trim() }) },
+    )
+    newPlaintextKey.value = { id: res.id, name: res.name, key: res.key }
+    newKeyName.value = ''
+    await loadIngestKeys()
+  } catch (e: any) {
+    error.value = 'ingest_key 発行失敗: ' + (e.message || String(e))
+  }
+}
+
+async function deleteIngestKey(k: IngestKey) {
+  if (!confirm(`ingest_key "${k.name}" を削除しますか?`)) return
+  try {
+    await apiFetch(`/notify/ingest-keys/${k.id}`, { method: 'DELETE' })
+    await loadIngestKeys()
+  } catch (e: any) {
+    error.value = 'ingest_key 削除失敗: ' + (e.message || String(e))
+  }
+}
+
+async function copyIngestKey(text: string) {
+  await navigator.clipboard.writeText(text)
+  success.value = 'コピーしました'
+}
+
+function dismissPlaintextKey() {
+  newPlaintextKey.value = null
+}
+
+onMounted(async () => {
+  await load()
+  await loadTenantSlug()
+  await loadIngestKeys()
+})
 </script>
 
 <template>
@@ -383,6 +466,92 @@ onMounted(load)
             コピー
           </button>
         </div>
+      </div>
+
+      <!-- ===== Email 受信設定 ===== -->
+      <div class="bg-white rounded-lg shadow border p-4 mt-8">
+        <h3 class="font-medium mb-3">Email 受信設定</h3>
+        <p class="text-sm text-gray-500 mb-3">
+          外部からメール経由で添付ファイルを受け取り、自動で「受信メール」一覧に追加します。
+        </p>
+
+        <div class="bg-blue-50 border border-blue-200 rounded p-3 mb-4">
+          <div class="text-xs text-blue-700 mb-1">受信用メールアドレス</div>
+          <code class="text-sm font-mono select-all">{{ ingestEmailAddress || '(テナント情報取得中...)' }}</code>
+          <p class="text-xs text-blue-600 mt-1">
+            このアドレス宛に PDF 等を添付してメール送信すると、テナントに紐づいて取り込まれます。
+          </p>
+        </div>
+
+        <!-- 新規発行 -->
+        <div class="border rounded p-3 mb-3">
+          <div class="text-sm font-medium mb-2">新しい ingest key を発行</div>
+          <div class="flex gap-2">
+            <input v-model="newKeyName" placeholder="名前 (例: production)"
+                   class="flex-1 border rounded px-3 py-2 text-sm" />
+            <button @click="createIngestKey" :disabled="!newKeyName.trim()"
+                    class="bg-blue-600 text-white px-4 py-2 rounded text-sm hover:bg-blue-700 disabled:opacity-50">
+              発行
+            </button>
+          </div>
+        </div>
+
+        <!-- 発行直後の plaintext 表示 (1回のみ) -->
+        <div v-if="newPlaintextKey" class="border-2 border-yellow-300 bg-yellow-50 rounded p-3 mb-3">
+          <div class="text-sm font-medium text-yellow-800 mb-2">
+            ⚠️ ingest_key を発行しました — このキーは二度と表示されません
+          </div>
+          <div class="text-xs mb-1">名前: {{ newPlaintextKey.name }}</div>
+          <input :value="newPlaintextKey.key" readonly
+                 class="w-full border rounded px-3 py-2 text-xs font-mono bg-white mb-2 select-all" />
+          <div class="flex gap-2">
+            <button @click="copyIngestKey(newPlaintextKey.key)"
+                    class="bg-blue-500 text-white px-3 py-1 rounded text-xs hover:bg-blue-600">
+              コピー
+            </button>
+            <button @click="dismissPlaintextKey"
+                    class="bg-gray-300 px-3 py-1 rounded text-xs hover:bg-gray-400">
+              閉じる
+            </button>
+          </div>
+          <p class="text-xs text-yellow-700 mt-2">
+            このキーを Cloudflare Workers の <code>INGEST_KEYS_KV</code> に
+            <code>tenant-{slug}</code> = この値 で登録すると、メール経由の受信が有効になります。
+          </p>
+        </div>
+
+        <!-- 一覧 -->
+        <div class="text-sm font-medium mb-2">発行済み ingest key</div>
+        <div v-if="ingestKeysLoading" class="text-xs text-gray-500">読み込み中...</div>
+        <div v-else-if="ingestKeys.length === 0" class="text-xs text-gray-500">
+          まだ発行されていません。
+        </div>
+        <table v-else class="w-full text-sm">
+          <thead class="text-left text-xs text-gray-500">
+            <tr>
+              <th class="py-1">名前</th>
+              <th class="py-1">作成日</th>
+              <th class="py-1">状態</th>
+              <th class="py-1"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <tr v-for="k in ingestKeys" :key="k.id">
+              <td class="py-1">{{ k.name }}</td>
+              <td class="py-1 text-gray-500">{{ new Date(k.created_at).toLocaleDateString('ja-JP') }}</td>
+              <td class="py-1">
+                <span class="text-xs px-2 py-0.5 rounded"
+                      :class="k.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'">
+                  {{ k.enabled ? '有効' : '無効' }}
+                </span>
+              </td>
+              <td class="py-1 text-right">
+                <button @click="deleteIngestKey(k)"
+                        class="text-xs text-red-600 hover:underline">削除</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
 
       <!-- メッセージ -->

--- a/workers/email-receiver/wrangler.toml
+++ b/workers/email-receiver/wrangler.toml
@@ -11,7 +11,7 @@ INGEST_ENDPOINT = "https://alc-api.ippoan.org/api/notify/ingest"
 # 例: tenant-acme@notify.ippoan.org → KV.get("tenant-acme") → ingest_key
 [[kv_namespaces]]
 binding = "INGEST_KEYS_KV"
-id = "REPLACE_WITH_PRODUCTION_KV_ID"
+id = "3339456a3c0343c99e6114dcf9f70efb"
 
 [env.staging]
 name = "notify-email-receiver-staging"
@@ -21,4 +21,4 @@ INGEST_ENDPOINT = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/noti
 
 [[env.staging.kv_namespaces]]
 binding = "INGEST_KEYS_KV"
-id = "REPLACE_WITH_STAGING_KV_ID"
+id = "7f1e4c04825148df9d4b9443ccee43c8"


### PR DESCRIPTION
Phase 2 (メール受信機能) のフロントエンド (PR 4/4)。

## 新規ページ

- `/emails` — 受信メール一覧 (送信者 / 件名 / 添付件数 / サイズ / 配信状況)
- `/emails/[id]` — メール詳細 + 添付ファイル管理:
  - メタデータ + 本文 (折りたたみ)
  - 添付ごとに [ダウンロード] [配信] [削除] ボタン
  - 配信履歴テーブル (送信日時 / 実行者 / 受信者 / 手段 / 状況 / 既読日時)

## settings.vue 拡張

「Email 受信設定」セクションを追加:
- ingest 用メールアドレス表示 (`tenant-{slug}@notify.ippoan.org`)
- ingest_key の発行 / 一覧 / 削除
- 発行直後の plaintext を1回だけ表示 (コピー可)

## バックエンド要件

PR #292 (rust-alc-api) のマージが前提:
- GET /api/notify/emails
- GET /api/notify/emails/{message_id}
- GET /api/notify/documents/{id}/download
- DELETE /api/notify/documents/{id}
- GET/POST/DELETE /api/notify/ingest-keys
- notify_deliveries.triggered_by_user_id (履歴の実行者表示用)

## 「いつ・だれが・どこに送ったか」

詳細ページの配信履歴テーブルで全網羅:
- 送信日時 → sent_at
- 実行者 → triggered_by_name / email
- 受信者 → recipient_name (複数可)
- 手段 → provider
- 状況 → status
- 既読日時 → read_at

## Test plan
- [ ] CI: typecheck + vitest
- [ ] CI: nuxt build (Cloudflare Workers preset)
- [ ] staging deploy → /emails で空一覧表示を確認
- [ ] staging で settings → ingest_key 発行 → KV 登録 → テストメール送信 → /emails に表示