### PR TITLE
feat(email-worker): silent drop + deploy CI

### DIFF
--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy Email Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'workers/email-receiver/**'
+      - '.github/workflows/email-worker-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ['', 'staging']
+    name: Deploy ${{ matrix.env || 'production' }}
+    defaults:
+      run:
+        working-directory: workers/email-receiver
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: workers/email-receiver/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npx vitest run
+
+      - name: Deploy (${{ matrix.env || 'production' }})
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: workers/email-receiver
+          command: deploy ${{ matrix.env && format('--env {0}', matrix.env) || '' }}

--- a/workers/email-receiver/package-lock.json
+++ b/workers/email-receiver/package-lock.json
@@ -2989,6 +2989,7 @@
       "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.1",
@@ -3010,6 +3011,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3194,6 +3196,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/workers/email-receiver/src/index.ts
+++ b/workers/email-receiver/src/index.ts
@@ -3,6 +3,8 @@ import PostalMime from "postal-mime";
 export interface Env {
   INGEST_ENDPOINT: string;
   INGEST_KEYS_KV: KVNamespace;
+  /** カンマ区切り。未設定なら全 host 許可 (主にローカルテスト用) */
+  ALLOWED_HOSTS?: string;
 }
 
 const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
@@ -10,15 +12,23 @@ const MAX_ATTACHMENTS = 20;
 
 export default {
   async email(message: ForwardableEmailMessage, env: Env, _ctx: ExecutionContext): Promise<void> {
-    const localPart = message.to.split("@")[0]?.toLowerCase();
-    if (!localPart) {
-      message.setReject("Missing local-part");
+    const [localPartRaw, hostRaw] = message.to.split("@");
+    const localPart = localPartRaw?.toLowerCase();
+    const host = hostRaw?.toLowerCase();
+    if (!localPart || !host) {
+      // local-part / host が取れない不正アドレス → 黙ってドロップ
+      return;
+    }
+
+    // catch-all で zone 全体を受けるため、想定外 host は silent drop
+    if (!isHostAllowed(host, env.ALLOWED_HOSTS)) {
       return;
     }
 
     const ingestKey = await env.INGEST_KEYS_KV.get(localPart);
     if (!ingestKey) {
-      message.setReject(`Unknown tenant local-part: ${localPart}`);
+      // 未登録 local-part は silent drop (bounce すると From 偽装で
+      // 第三者にバウンスメールが届く可能性があるため)
       return;
     }
 
@@ -57,7 +67,7 @@ export default {
     }
 
     if (encoded.length === 0) {
-      message.setReject("No attachments");
+      // 添付なしのメールは silent drop (一覧 UI に出さない)
       return;
     }
 
@@ -92,6 +102,12 @@ export default {
     }
   },
 };
+
+export function isHostAllowed(host: string, allowedHosts?: string): boolean {
+  if (!allowedHosts) return true;
+  const list = allowedHosts.split(",").map(h => h.trim().toLowerCase()).filter(Boolean);
+  return list.includes(host.toLowerCase());
+}
 
 export function uint8ArrayToBase64(bytes: Uint8Array): string {
   let binary = "";

--- a/workers/email-receiver/tests/index.test.ts
+++ b/workers/email-receiver/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import worker, { uint8ArrayToBase64 } from "../src/index";
+import worker, { isHostAllowed, uint8ArrayToBase64 } from "../src/index";
 
 function makeMessage(overrides: Partial<{
   to: string;
@@ -48,6 +48,28 @@ function makeEnv(overrides: Partial<{
   };
 }
 
+describe("isHostAllowed", () => {
+  it("returns true when ALLOWED_HOSTS is undefined", () => {
+    expect(isHostAllowed("any.example.com")).toBe(true);
+  });
+
+  it("matches single host", () => {
+    expect(isHostAllowed("notify.ippoan.org", "notify.ippoan.org")).toBe(true);
+    expect(isHostAllowed("evil.com", "notify.ippoan.org")).toBe(false);
+  });
+
+  it("matches comma-separated host list with whitespace", () => {
+    const list = " notify.ippoan.org , notify-staging.ippoan.org ";
+    expect(isHostAllowed("notify.ippoan.org", list)).toBe(true);
+    expect(isHostAllowed("notify-staging.ippoan.org", list)).toBe(true);
+    expect(isHostAllowed("ippoan.org", list)).toBe(false);
+  });
+
+  it("is case insensitive on host", () => {
+    expect(isHostAllowed("Notify.Ippoan.Org", "notify.ippoan.org")).toBe(true);
+  });
+});
+
 describe("uint8ArrayToBase64", () => {
   it("encodes empty bytes to empty string", () => {
     expect(uint8ArrayToBase64(new Uint8Array(0))).toBe("");
@@ -70,18 +92,24 @@ describe("email worker", () => {
     vi.restoreAllMocks();
   });
 
-  it("rejects when local-part is missing", async () => {
+  it("silently drops when local-part is missing", async () => {
     const msg = makeMessage({ to: "@notify.ippoan.org" });
     await worker.email(msg, makeEnv(), {} as ExecutionContext);
-    expect(msg.setReject).toHaveBeenCalledWith("Missing local-part");
+    expect(msg.setReject).not.toHaveBeenCalled();
   });
 
-  it("rejects when KV has no key for tenant", async () => {
+  it("silently drops when host is not in ALLOWED_HOSTS", async () => {
+    const msg = makeMessage({ to: "tenant-acme@other.example.com" });
+    const env = makeEnv();
+    (env as any).ALLOWED_HOSTS = "notify.ippoan.org";
+    await worker.email(msg, env, {} as ExecutionContext);
+    expect(msg.setReject).not.toHaveBeenCalled();
+  });
+
+  it("silently drops when KV has no key for tenant", async () => {
     const msg = makeMessage();
     await worker.email(msg, makeEnv({ kvValue: null }), {} as ExecutionContext);
-    expect(msg.setReject).toHaveBeenCalledWith(
-      expect.stringContaining("Unknown tenant"),
-    );
+    expect(msg.setReject).not.toHaveBeenCalled();
   });
 
   it("rejects when MIME parse fails", async () => {
@@ -96,7 +124,7 @@ describe("email worker", () => {
     expect(msg.setReject).toHaveBeenCalledWith(expect.stringContaining("MIME parse failed"));
   });
 
-  it("rejects when no attachments are present", async () => {
+  it("silently drops when no attachments are present", async () => {
     const raw = new TextEncoder().encode(
       [
         "From: sender@example.com",
@@ -109,7 +137,7 @@ describe("email worker", () => {
     );
     const msg = makeMessage({ raw });
     await worker.email(msg, makeEnv(), {} as ExecutionContext);
-    expect(msg.setReject).toHaveBeenCalledWith("No attachments");
+    expect(msg.setReject).not.toHaveBeenCalled();
   });
 
   it("forwards parsed payload to ingest endpoint", async () => {

--- a/workers/email-receiver/wrangler.toml
+++ b/workers/email-receiver/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 # 本番: notify.ippoan.org に届いたメールを受ける
 [vars]
 INGEST_ENDPOINT = "https://alc-api.ippoan.org/api/notify/ingest"
+ALLOWED_HOSTS = "notify.ippoan.org"
 
 # テナントごとの ingest_key を保持 (key=local-part, value=plaintext key)
 # 例: tenant-acme@notify.ippoan.org → KV.get("tenant-acme") → ingest_key
@@ -18,6 +19,7 @@ name = "notify-email-receiver-staging"
 
 [env.staging.vars]
 INGEST_ENDPOINT = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/notify/ingest"
+ALLOWED_HOSTS = "notify-staging.ippoan.org"
 
 [[env.staging.kv_namespaces]]
 binding = "INGEST_KEYS_KV"


### PR DESCRIPTION
Phase 2 (メール受信) の近似仕上げ。

## Worker コード変更

zone catch-all → Worker という Cloudflare Email Routing の workaround 設定だと、Worker は `@ippoan.org` 全体のメールを受ける。そのとき未登録アドレスへのメールを `setReject` すると:

- 送信元にバウンスされる (現在の zone catch-all=drop 動作と不一致)
- From 偽装のメールだと第三者にバウンスが飛ぶ

よって:
- `ALLOWED_HOSTS` env (コンマ区切り) で受信可能ドメインを限定
- 不正アドレス / 想定外 host / KV miss / 添付ゼロ → silent drop
- バウンスは MIME parse 失敗 / 25MB 超 / 上流 ingest 5xx のみ

## CI 追加

`.github/workflows/email-worker-deploy.yml`:
- main push で `workers/email-receiver/**` が変わったら自動リリース
- matrix: 本番 + staging 両方をデプロイ
- typecheck → vitest 16 ケース → cloudflare/wrangler-action@v3
- secret: org-level `CLOUDFLARE_API_TOKEN`

## Test plan
- [ ] CI: typecheck + vitest + deploy job が prod / staging 両方で success
- [ ] CF ダッシュボードで Worker が 2つ表示されることを確認
- [ ] その後私が API で zone catch-all を drop → `notify-email-receiver` に切り替え