### PR TITLE
ci(email-worker): use reusable frontend-ci.yml with project_type=worker

### DIFF
--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Email Worker
+name: Email Worker CI
 
 on:
   push:
@@ -6,43 +6,31 @@ on:
     paths:
       - 'workers/email-receiver/**'
       - '.github/workflows/email-worker-deploy.yml'
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+    paths:
+      - 'workers/email-receiver/**'
+      - '.github/workflows/email-worker-deploy.yml'
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  packages: read
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        env: ['', 'staging']
-    name: Deploy ${{ matrix.env || 'production' }}
-    defaults:
-      run:
-        working-directory: workers/email-receiver
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: workers/email-receiver/package-lock.json
-
-      - name: Install
-        run: npm ci
-
-      - name: Typecheck
-        run: npx tsc --noEmit
-
-      - name: Test
-        run: npx vitest run
-
-      - name: Deploy (${{ matrix.env || 'production' }})
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          workingDirectory: workers/email-receiver
-          command: deploy ${{ matrix.env && format('--env {0}', matrix.env) || '' }}
+  ci:
+    uses: ippoan/ci-workflows/.github/workflows/frontend-ci.yml@main
+    with:
+      project_type: 'worker'
+      working_directory: 'workers/email-receiver'
+      cache_dependency_path: 'workers/email-receiver/package-lock.json'
+      install_command: 'npm ci'
+      typecheck_command: 'npx tsc --noEmit'
+      test_command: 'npx vitest run'
+      has_integration: false
+      has_tests: true
+      has_deploy: true
+      has_staging_deploy: true
+    secrets: inherit


### PR DESCRIPTION
ippoan/ci-workflows/.github/workflows/frontend-ci.yml が project_type='worker' をサポートしているのを利用して、自前の cloudflare/wrangler-action 呼び出しを reusable に置き換え。

## 変更点

- working_directory='workers/email-receiver' で test/typecheck/release を全部その配下で実行
- typecheck_command: 'npx tsc --noEmit' (worker のデフォルトと一致)
- test_command: 'npx vitest run' (coverage threshold は worker 自前 vitest.config.ts 任せ)
- has_integration: false
- staging リリース: PR 時、production リリース: v* タグ push 時 (reusable の標準パターン)

## なぜ前のは失敗したか

cloudflare/wrangler-action@v3 は workingDirectory input があるが、root の wrangler.jsonc (Nuxt 用) を先に拾ってしまい .output/server/index.mjs が見つからずエラーになった。reusable は内部で cd ${{ inputs.working_directory }} 後に npx 経由で release コマンドを叩くため衝突しない。

## Test plan
- [ ] PR トリガで staging リリース成功
- [ ] CF ダッシュボードで notify-email-receiver-staging が新規作成されている
- [ ] 後続の v* タグ push で production リリースが走る