### PR TITLE
ci(email-worker): explicit --config wrangler.toml

### DIFF
--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -29,6 +29,10 @@ jobs:
       install_command: 'npm ci'
       typecheck_command: 'npx tsc --noEmit'
       test_command: 'npx vitest run'
+      # deploy_*_script を明示指定して --config wrangler.toml を必ず読ませる。
+      # 直前に pwd / ls をログに出して CWD と config 解決を可視化。
+      deploy_staging_script: 'pwd && ls && npx wrangler deploy --env staging --config wrangler.toml'
+      deploy_release_script: 'pwd && ls && npx wrangler deploy --config wrangler.toml'
       has_integration: false
       has_tests: true
       has_deploy: true


### PR DESCRIPTION
PR #32 の staging release が \".output/server/index.mjs\" not found で落ちた。これは Nuxt 用 root wrangler.jsonc の main 値で、worker dir の wrangler.toml を見ていないことを示す。

reusable の defaults.run.working-directory は test/typecheck では効いているが (ls/typecheck pass)、release ステップ → wrangler の config 解決で何故か上書きされる。

回避策として deploy_staging_script / deploy_release_script を明示し、--config wrangler.toml を強制 + pwd/ls を log に残してデバッグ可視化。

## Test plan
- [ ] PR トリガで staging release ログに pwd=workers/email-receiver と ls 出力が見える
- [ ] wrangler が src/index.ts (worker config) を main として認識しリリース成功