### PR TITLE
ci(email-worker): set account_id to avoid /memberships permission failure

### DIFF
--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -29,10 +29,10 @@ jobs:
       install_command: 'npm ci'
       typecheck_command: 'npx tsc --noEmit'
       test_command: 'npx vitest run'
-      # deploy_*_script を明示指定して --config wrangler.toml を必ず読ませる。
-      # 直前に pwd / ls をログに出して CWD と config 解決を可視化。
-      deploy_staging_script: 'pwd && ls && npx wrangler deploy --env staging --config wrangler.toml'
-      deploy_release_script: 'pwd && ls && npx wrangler deploy --config wrangler.toml'
+      # working_directory が反映されない / wrangler が root の wrangler.jsonc を拾う
+      # ケースを避けるため --config を明示。
+      deploy_staging_script: 'npx wrangler deploy --env staging --config wrangler.toml'
+      deploy_release_script: 'npx wrangler deploy --config wrangler.toml'
       has_integration: false
       has_tests: true
       has_deploy: true

--- a/workers/email-receiver/wrangler.toml
+++ b/workers/email-receiver/wrangler.toml
@@ -2,6 +2,7 @@ name = "notify-email-receiver"
 main = "src/index.ts"
 compatibility_date = "2026-04-01"
 compatibility_flags = ["nodejs_compat"]
+account_id = "24b45709d060d957340180e995f0d373"
 
 # 本番: notify.ippoan.org に届いたメールを受ける
 [vars]


### PR DESCRIPTION
PR #33 で staging release が `/memberships` API failure (token に scope 無し) で落ちる。

原因: Nuxt root の wrangler.jsonc には account_id が書かれているが、worker 側 wrangler.toml には無く、wrangler が account 自動検出のため /memberships を叩いていた。

修正:
- account_id = "24b45709d060d957340180e995f0d373" を worker wrangler.toml に追加
- ついでに pwd/ls 診断 echo を削除して deploy script を簡素化

## Test plan
- [ ] PR トリガで staging release 成功 → notify-email-receiver-staging が CF 上に作成される
- [ ] PR の Auto Merge で main 反映後、CI が次に v* タグ push を待つ