### PR TITLE
feat(email-worker): host-based dispatch (prod / staging) in single Worker

### DIFF
--- a/workers/email-receiver/src/index.ts
+++ b/workers/email-receiver/src/index.ts
@@ -1,14 +1,42 @@
 import PostalMime from "postal-mime";
 
 export interface Env {
+  /** 本番 ingest エンドポイント (notify.ippoan.org 用) */
   INGEST_ENDPOINT: string;
+  /** 本番 KV namespace (tenant-{slug} → plaintext ingest_key) */
   INGEST_KEYS_KV: KVNamespace;
-  /** カンマ区切り。未設定なら全 host 許可 (主にローカルテスト用) */
-  ALLOWED_HOSTS?: string;
+
+  /** staging ingest エンドポイント (notify-staging.ippoan.org 用、任意) */
+  INGEST_ENDPOINT_STAGING?: string;
+  /** staging KV namespace (任意) */
+  INGEST_KEYS_KV_STAGING?: KVNamespace;
+
+  /** 本番ホスト名 (デフォルト notify.ippoan.org) */
+  PROD_HOST?: string;
+  /** staging ホスト名 (デフォルト notify-staging.ippoan.org) */
+  STAGING_HOST?: string;
 }
 
 const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
 const MAX_ATTACHMENTS = 20;
+
+interface RouteTarget {
+  endpoint: string;
+  kv: KVNamespace;
+}
+
+export function pickRoute(host: string, env: Env): RouteTarget | null {
+  const prodHost = (env.PROD_HOST ?? "notify.ippoan.org").toLowerCase();
+  const stagingHost = (env.STAGING_HOST ?? "notify-staging.ippoan.org").toLowerCase();
+  const h = host.toLowerCase();
+  if (h === prodHost) {
+    return { endpoint: env.INGEST_ENDPOINT, kv: env.INGEST_KEYS_KV };
+  }
+  if (h === stagingHost && env.INGEST_ENDPOINT_STAGING && env.INGEST_KEYS_KV_STAGING) {
+    return { endpoint: env.INGEST_ENDPOINT_STAGING, kv: env.INGEST_KEYS_KV_STAGING };
+  }
+  return null;
+}
 
 export default {
   async email(message: ForwardableEmailMessage, env: Env, _ctx: ExecutionContext): Promise<void> {
@@ -16,19 +44,17 @@ export default {
     const localPart = localPartRaw?.toLowerCase();
     const host = hostRaw?.toLowerCase();
     if (!localPart || !host) {
-      // local-part / host が取れない不正アドレス → 黙ってドロップ
       return;
     }
 
-    // catch-all で zone 全体を受けるため、想定外 host は silent drop
-    if (!isHostAllowed(host, env.ALLOWED_HOSTS)) {
+    // host → (endpoint, KV) を選択。未対応 host は silent drop。
+    const route = pickRoute(host, env);
+    if (!route) {
       return;
     }
 
-    const ingestKey = await env.INGEST_KEYS_KV.get(localPart);
+    const ingestKey = await route.kv.get(localPart);
     if (!ingestKey) {
-      // 未登録 local-part は silent drop (bounce すると From 偽装で
-      // 第三者にバウンスメールが届く可能性があるため)
       return;
     }
 
@@ -67,7 +93,6 @@ export default {
     }
 
     if (encoded.length === 0) {
-      // 添付なしのメールは silent drop (一覧 UI に出さない)
       return;
     }
 
@@ -82,7 +107,7 @@ export default {
 
     let res: Response;
     try {
-      res = await fetch(env.INGEST_ENDPOINT, {
+      res = await fetch(route.endpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -102,12 +127,6 @@ export default {
     }
   },
 };
-
-export function isHostAllowed(host: string, allowedHosts?: string): boolean {
-  if (!allowedHosts) return true;
-  const list = allowedHosts.split(",").map(h => h.trim().toLowerCase()).filter(Boolean);
-  return list.includes(host.toLowerCase());
-}
 
 export function uint8ArrayToBase64(bytes: Uint8Array): string {
   let binary = "";

--- a/workers/email-receiver/tests/index.test.ts
+++ b/workers/email-receiver/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import worker, { isHostAllowed, uint8ArrayToBase64 } from "../src/index";
+import worker, { pickRoute, uint8ArrayToBase64 } from "../src/index";
 
 function makeMessage(overrides: Partial<{
   to: string;
@@ -35,38 +35,74 @@ function makeMessage(overrides: Partial<{
   } as unknown as ForwardableEmailMessage & { setReject: typeof setReject };
 }
 
-function makeEnv(overrides: Partial<{
-  INGEST_ENDPOINT: string;
-  kvValue: string | null;
-}> = {}) {
-  const kv = {
-    get: vi.fn().mockResolvedValue(overrides.kvValue === undefined ? "test-ingest-key" : overrides.kvValue),
-  };
+function makeKv(value: string | null = "test-ingest-key") {
+  return { get: vi.fn().mockResolvedValue(value) } as unknown as KVNamespace;
+}
+
+function makeEnv(overrides: {
+  prodEndpoint?: string;
+  prodKvValue?: string | null;
+  stagingEndpoint?: string;
+  stagingKvValue?: string | null;
+} = {}) {
+  // 注: ?? は null も default にしてしまうので、undefined のみ default 扱いにする
+  const prodVal = "prodKvValue" in overrides ? overrides.prodKvValue! : "test-ingest-key";
+  const stagingVal = "stagingKvValue" in overrides ? overrides.stagingKvValue! : "test-staging-key";
   return {
-    INGEST_ENDPOINT: overrides.INGEST_ENDPOINT ?? "https://example.invalid/api/notify/ingest",
-    INGEST_KEYS_KV: kv as unknown as KVNamespace,
+    INGEST_ENDPOINT: overrides.prodEndpoint ?? "https://prod.invalid/api/notify/ingest",
+    INGEST_KEYS_KV: makeKv(prodVal),
+    INGEST_ENDPOINT_STAGING: overrides.stagingEndpoint ?? "https://staging.invalid/api/notify/ingest",
+    INGEST_KEYS_KV_STAGING: makeKv(stagingVal),
   };
 }
 
-describe("isHostAllowed", () => {
-  it("returns true when ALLOWED_HOSTS is undefined", () => {
-    expect(isHostAllowed("any.example.com")).toBe(true);
+describe("pickRoute", () => {
+  it("routes notify.ippoan.org to prod", () => {
+    const env = makeEnv();
+    const r = pickRoute("notify.ippoan.org", env as any);
+    expect(r?.endpoint).toBe("https://prod.invalid/api/notify/ingest");
+    expect(r?.kv).toBe(env.INGEST_KEYS_KV);
   });
 
-  it("matches single host", () => {
-    expect(isHostAllowed("notify.ippoan.org", "notify.ippoan.org")).toBe(true);
-    expect(isHostAllowed("evil.com", "notify.ippoan.org")).toBe(false);
+  it("routes notify-staging.ippoan.org to staging", () => {
+    const env = makeEnv();
+    const r = pickRoute("notify-staging.ippoan.org", env as any);
+    expect(r?.endpoint).toBe("https://staging.invalid/api/notify/ingest");
+    expect(r?.kv).toBe(env.INGEST_KEYS_KV_STAGING);
   });
 
-  it("matches comma-separated host list with whitespace", () => {
-    const list = " notify.ippoan.org , notify-staging.ippoan.org ";
-    expect(isHostAllowed("notify.ippoan.org", list)).toBe(true);
-    expect(isHostAllowed("notify-staging.ippoan.org", list)).toBe(true);
-    expect(isHostAllowed("ippoan.org", list)).toBe(false);
+  it("returns null for unknown host", () => {
+    const env = makeEnv();
+    expect(pickRoute("ippoan.org", env as any)).toBeNull();
+    expect(pickRoute("evil.example.com", env as any)).toBeNull();
   });
 
-  it("is case insensitive on host", () => {
-    expect(isHostAllowed("Notify.Ippoan.Org", "notify.ippoan.org")).toBe(true);
+  it("staging routing requires both env vars", () => {
+    const env: any = {
+      INGEST_ENDPOINT: "https://prod.invalid",
+      INGEST_KEYS_KV: makeKv(),
+      // INGEST_ENDPOINT_STAGING / INGEST_KEYS_KV_STAGING 未設定
+    };
+    expect(pickRoute("notify-staging.ippoan.org", env)).toBeNull();
+  });
+
+  it("respects PROD_HOST / STAGING_HOST overrides", () => {
+    const env: any = {
+      INGEST_ENDPOINT: "https://prod.invalid",
+      INGEST_KEYS_KV: makeKv(),
+      INGEST_ENDPOINT_STAGING: "https://stg.invalid",
+      INGEST_KEYS_KV_STAGING: makeKv(),
+      PROD_HOST: "mail.example.com",
+      STAGING_HOST: "mail-stg.example.com",
+    };
+    expect(pickRoute("mail.example.com", env)?.endpoint).toBe("https://prod.invalid");
+    expect(pickRoute("mail-stg.example.com", env)?.endpoint).toBe("https://stg.invalid");
+    expect(pickRoute("notify.ippoan.org", env)).toBeNull();
+  });
+
+  it("is case insensitive", () => {
+    const env = makeEnv();
+    expect(pickRoute("Notify.Ippoan.Org", env as any)?.endpoint).toBe("https://prod.invalid/api/notify/ingest");
   });
 });
 
@@ -94,32 +130,29 @@ describe("email worker", () => {
 
   it("silently drops when local-part is missing", async () => {
     const msg = makeMessage({ to: "@notify.ippoan.org" });
-    await worker.email(msg, makeEnv(), {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
-  it("silently drops when host is not in ALLOWED_HOSTS", async () => {
+  it("silently drops when host is unknown", async () => {
     const msg = makeMessage({ to: "tenant-acme@other.example.com" });
-    const env = makeEnv();
-    (env as any).ALLOWED_HOSTS = "notify.ippoan.org";
-    await worker.email(msg, env, {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
-  it("silently drops when KV has no key for tenant", async () => {
+  it("silently drops when prod KV has no key for tenant", async () => {
     const msg = makeMessage();
-    await worker.email(msg, makeEnv({ kvValue: null }), {} as ExecutionContext);
+    await worker.email(msg, makeEnv({ prodKvValue: null }) as any, {} as ExecutionContext);
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
   it("rejects when MIME parse fails", async () => {
     const msg = makeMessage({ raw: new TextEncoder().encode("\x00not-mime") });
-    // postal-mime is forgiving — to force failure we patch parse
     const PostalMime = (await import("postal-mime")).default;
     const spy = vi
       .spyOn(PostalMime, "parse")
       .mockRejectedValueOnce(new Error("bad"));
-    await worker.email(msg, makeEnv(), {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(spy).toHaveBeenCalled();
     expect(msg.setReject).toHaveBeenCalledWith(expect.stringContaining("MIME parse failed"));
   });
@@ -136,28 +169,38 @@ describe("email worker", () => {
       ].join("\r\n"),
     );
     const msg = makeMessage({ raw });
-    await worker.email(msg, makeEnv(), {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
-  it("forwards parsed payload to ingest endpoint", async () => {
+  it("forwards prod email to prod ingest endpoint with prod key", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(null, { status: 201 }));
 
-    const msg = makeMessage();
-    await worker.email(msg, makeEnv(), {} as ExecutionContext);
+    const msg = makeMessage({ to: "tenant-acme@notify.ippoan.org" });
+    const env = makeEnv({ prodKvValue: "PROD_KEY" });
+    await worker.email(msg, env as any, {} as ExecutionContext);
 
     expect(msg.setReject).not.toHaveBeenCalled();
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0]!;
-    expect(url).toBe("https://example.invalid/api/notify/ingest");
-    const headers = (init as RequestInit).headers as Record<string, string>;
-    expect(headers["X-Ingest-Key"]).toBe("test-ingest-key");
-    const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.attachments).toHaveLength(1);
-    expect(body.attachments[0].filename).toBe("a.pdf");
-    expect(body.from).toBe("sender@example.com");
+    expect(url).toBe("https://prod.invalid/api/notify/ingest");
+    expect((init as RequestInit).headers).toMatchObject({ "X-Ingest-Key": "PROD_KEY" });
+  });
+
+  it("forwards staging email to staging ingest endpoint with staging key", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 201 }));
+
+    const msg = makeMessage({ to: "tenant-acme@notify-staging.ippoan.org" });
+    const env = makeEnv({ stagingKvValue: "STAGING_KEY" });
+    await worker.email(msg, env as any, {} as ExecutionContext);
+
+    expect(msg.setReject).not.toHaveBeenCalled();
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://staging.invalid/api/notify/ingest");
+    expect((init as RequestInit).headers).toMatchObject({ "X-Ingest-Key": "STAGING_KEY" });
   });
 
   it("rejects when ingest endpoint returns non-OK", async () => {
@@ -165,7 +208,7 @@ describe("email worker", () => {
       new Response("upstream error", { status: 500 }),
     );
     const msg = makeMessage();
-    await worker.email(msg, makeEnv(), {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(msg.setReject).toHaveBeenCalledWith(
       expect.stringContaining("Ingest failed: 500"),
     );
@@ -174,14 +217,13 @@ describe("email worker", () => {
   it("rejects when fetch itself throws", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
     const msg = makeMessage();
-    await worker.email(msg, makeEnv(), {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(msg.setReject).toHaveBeenCalledWith(
       expect.stringContaining("Ingest fetch failed"),
     );
   });
 
   it("rejects when total attachments exceed 25MB", async () => {
-    // Inject parsed object with one huge attachment via PostalMime mock
     const PostalMime = (await import("postal-mime")).default;
     vi.spyOn(PostalMime, "parse").mockResolvedValueOnce({
       from: { address: "a@b" },
@@ -197,7 +239,7 @@ describe("email worker", () => {
       ],
     } as any);
     const msg = makeMessage();
-    await worker.email(msg, makeEnv(), {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(msg.setReject).toHaveBeenCalledWith("Attachments exceed 25MB total");
   });
 });

--- a/workers/email-receiver/wrangler.toml
+++ b/workers/email-receiver/wrangler.toml
@@ -4,24 +4,41 @@ compatibility_date = "2026-04-01"
 compatibility_flags = ["nodejs_compat"]
 account_id = "24b45709d060d957340180e995f0d373"
 
-# 本番: notify.ippoan.org に届いたメールを受ける
+# 本番 Worker は zone catch-all で *@ippoan.org を全て受け、host で分岐:
+#   tenant-{slug}@notify.ippoan.org         → INGEST_KEYS_KV (prod) + INGEST_ENDPOINT
+#   tenant-{slug}@notify-staging.ippoan.org → INGEST_KEYS_KV_STAGING + INGEST_ENDPOINT_STAGING
+# それ以外の host (例: random@ippoan.org) は silent drop。
+
 [vars]
 INGEST_ENDPOINT = "https://alc-api.ippoan.org/api/notify/ingest"
-ALLOWED_HOSTS = "notify.ippoan.org"
+INGEST_ENDPOINT_STAGING = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/notify/ingest"
+PROD_HOST = "notify.ippoan.org"
+STAGING_HOST = "notify-staging.ippoan.org"
 
 # テナントごとの ingest_key を保持 (key=local-part, value=plaintext key)
-# 例: tenant-acme@notify.ippoan.org → KV.get("tenant-acme") → ingest_key
 [[kv_namespaces]]
 binding = "INGEST_KEYS_KV"
 id = "3339456a3c0343c99e6114dcf9f70efb"
 
+[[kv_namespaces]]
+binding = "INGEST_KEYS_KV_STAGING"
+id = "7f1e4c04825148df9d4b9443ccee43c8"
+
+# staging Worker (notify-email-receiver-staging) は CI 都合で deploy はされるが
+# Email Routing の catch-all は1つしか持てないので実質受信しない。
+# 手元 wrangler dev / canary 用途のみ想定。
 [env.staging]
 name = "notify-email-receiver-staging"
 
 [env.staging.vars]
 INGEST_ENDPOINT = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/notify/ingest"
-ALLOWED_HOSTS = "notify-staging.ippoan.org"
+PROD_HOST = "notify-staging.ippoan.org"
+STAGING_HOST = "notify-staging.ippoan.org"
 
 [[env.staging.kv_namespaces]]
 binding = "INGEST_KEYS_KV"
+id = "7f1e4c04825148df9d4b9443ccee43c8"
+
+[[env.staging.kv_namespaces]]
+binding = "INGEST_KEYS_KV_STAGING"
 id = "7f1e4c04825148df9d4b9443ccee43c8"


### PR DESCRIPTION
Cloudflare Email Routing の zone catch-all は1つしか持てないため、prod Worker が `*@ippoan.org` 全体を受ける。Worker 内で host で endpoint + KV を切り替えるよう拡張。

## ルーティング

- `tenant-{slug}@notify.ippoan.org` → INGEST_ENDPOINT (prod) + INGEST_KEYS_KV (prod)
- `tenant-{slug}@notify-staging.ippoan.org` → INGEST_ENDPOINT_STAGING + INGEST_KEYS_KV_STAGING
- それ以外 → silent drop

これで staging UI から ingest_key を発行して staging email を試せるようになる。

## test

- pickRoute 単体テスト: 6 ケース (case-insensitive、override 等含む)
- worker email() 統合テスト: prod/staging 両方のフローを検証
- 全 19 ケース pass

## Test plan
- [x] vitest 19/19 ローカル pass
- [ ] CI typecheck + vitest pass
- [ ] staging tag → release で wrangler.toml 反映
- [ ] notify-staging.ippoan.org に試験メール送信して /emails (staging) に出るか