### PR TITLE
refactor(notify): Worker shared secret + tenant_slug

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -199,40 +199,19 @@ async function remove() {
   }
 }
 
-// ===== Email 受信設定 (ingest keys) =====
-interface IngestKey {
-  id: string
-  name: string
-  enabled: boolean
-  created_at: string
-}
-const ingestKeys = ref<IngestKey[]>([])
-const ingestKeysLoading = ref(false)
-const newKeyName = ref('')
-const newPlaintextKey = ref<{ id: string; name: string; key: string } | null>(null)
+// ===== Email 受信設定 =====
+const tenantSlug = ref<string>('')
 
 const ingestEmailDomain = computed(() => {
-  // 本番判定: apiBase ホスト名から推定。最終的には API/Cloudflare 設定と整合させる必要あり。
+  // 本番判定: apiBase ホスト名から推定。Cloudflare Email Routing 側の設定と整合させる。
   if (apiBase.includes('alc-api.ippoan.org')) return 'notify.ippoan.org'
   return 'notify-staging.ippoan.org'
 })
 
-const tenantSlug = ref<string>('')
 const ingestEmailAddress = computed(() => {
   if (!tenantSlug.value) return ''
   return `tenant-${tenantSlug.value}@${ingestEmailDomain.value}`
 })
-
-async function loadIngestKeys() {
-  ingestKeysLoading.value = true
-  try {
-    ingestKeys.value = await apiFetch<IngestKey[]>('/notify/ingest-keys')
-  } catch (e: any) {
-    error.value = 'ingest_keys 取得失敗: ' + (e.message || String(e))
-  } finally {
-    ingestKeysLoading.value = false
-  }
-}
 
 async function loadTenantSlug() {
   try {
@@ -244,44 +223,9 @@ async function loadTenantSlug() {
   }
 }
 
-async function createIngestKey() {
-  if (!newKeyName.value.trim()) return
-  try {
-    const res = await apiFetch<{ id: string; name: string; key: string }>(
-      '/notify/ingest-keys',
-      { method: 'POST', body: JSON.stringify({ name: newKeyName.value.trim() }) },
-    )
-    newPlaintextKey.value = { id: res.id, name: res.name, key: res.key }
-    newKeyName.value = ''
-    await loadIngestKeys()
-  } catch (e: any) {
-    error.value = 'ingest_key 発行失敗: ' + (e.message || String(e))
-  }
-}
-
-async function deleteIngestKey(k: IngestKey) {
-  if (!confirm(`ingest_key "${k.name}" を削除しますか?`)) return
-  try {
-    await apiFetch(`/notify/ingest-keys/${k.id}`, { method: 'DELETE' })
-    await loadIngestKeys()
-  } catch (e: any) {
-    error.value = 'ingest_key 削除失敗: ' + (e.message || String(e))
-  }
-}
-
-async function copyIngestKey(text: string) {
-  await navigator.clipboard.writeText(text)
-  success.value = 'コピーしました'
-}
-
-function dismissPlaintextKey() {
-  newPlaintextKey.value = null
-}
-
 onMounted(async () => {
   await load()
   await loadTenantSlug()
-  await loadIngestKeys()
 })
 </script>
 
@@ -475,83 +419,13 @@ onMounted(async () => {
           外部からメール経由で添付ファイルを受け取り、自動で「受信メール」一覧に追加します。
         </p>
 
-        <div class="bg-blue-50 border border-blue-200 rounded p-3 mb-4">
+        <div class="bg-blue-50 border border-blue-200 rounded p-3">
           <div class="text-xs text-blue-700 mb-1">受信用メールアドレス</div>
           <code class="text-sm font-mono select-all">{{ ingestEmailAddress || '(テナント情報取得中...)' }}</code>
           <p class="text-xs text-blue-600 mt-1">
             このアドレス宛に PDF 等を添付してメール送信すると、テナントに紐づいて取り込まれます。
           </p>
         </div>
-
-        <!-- 新規発行 -->
-        <div class="border rounded p-3 mb-3">
-          <div class="text-sm font-medium mb-2">新しい ingest key を発行</div>
-          <div class="flex gap-2">
-            <input v-model="newKeyName" placeholder="名前 (例: production)"
-                   class="flex-1 border rounded px-3 py-2 text-sm" />
-            <button @click="createIngestKey" :disabled="!newKeyName.trim()"
-                    class="bg-blue-600 text-white px-4 py-2 rounded text-sm hover:bg-blue-700 disabled:opacity-50">
-              発行
-            </button>
-          </div>
-        </div>
-
-        <!-- 発行直後の plaintext 表示 (1回のみ) -->
-        <div v-if="newPlaintextKey" class="border-2 border-yellow-300 bg-yellow-50 rounded p-3 mb-3">
-          <div class="text-sm font-medium text-yellow-800 mb-2">
-            ⚠️ ingest_key を発行しました — このキーは二度と表示されません
-          </div>
-          <div class="text-xs mb-1">名前: {{ newPlaintextKey.name }}</div>
-          <input :value="newPlaintextKey.key" readonly
-                 class="w-full border rounded px-3 py-2 text-xs font-mono bg-white mb-2 select-all" />
-          <div class="flex gap-2">
-            <button @click="copyIngestKey(newPlaintextKey.key)"
-                    class="bg-blue-500 text-white px-3 py-1 rounded text-xs hover:bg-blue-600">
-              コピー
-            </button>
-            <button @click="dismissPlaintextKey"
-                    class="bg-gray-300 px-3 py-1 rounded text-xs hover:bg-gray-400">
-              閉じる
-            </button>
-          </div>
-          <p class="text-xs text-yellow-700 mt-2">
-            このキーを Cloudflare Workers の <code>INGEST_KEYS_KV</code> に
-            <code>tenant-{slug}</code> = この値 で登録すると、メール経由の受信が有効になります。
-          </p>
-        </div>
-
-        <!-- 一覧 -->
-        <div class="text-sm font-medium mb-2">発行済み ingest key</div>
-        <div v-if="ingestKeysLoading" class="text-xs text-gray-500">読み込み中...</div>
-        <div v-else-if="ingestKeys.length === 0" class="text-xs text-gray-500">
-          まだ発行されていません。
-        </div>
-        <table v-else class="w-full text-sm">
-          <thead class="text-left text-xs text-gray-500">
-            <tr>
-              <th class="py-1">名前</th>
-              <th class="py-1">作成日</th>
-              <th class="py-1">状態</th>
-              <th class="py-1"></th>
-            </tr>
-          </thead>
-          <tbody class="divide-y">
-            <tr v-for="k in ingestKeys" :key="k.id">
-              <td class="py-1">{{ k.name }}</td>
-              <td class="py-1 text-gray-500">{{ new Date(k.created_at).toLocaleDateString('ja-JP') }}</td>
-              <td class="py-1">
-                <span class="text-xs px-2 py-0.5 rounded"
-                      :class="k.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'">
-                  {{ k.enabled ? '有効' : '無効' }}
-                </span>
-              </td>
-              <td class="py-1 text-right">
-                <button @click="deleteIngestKey(k)"
-                        class="text-xs text-red-600 hover:underline">削除</button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
       </div>
 
       <!-- メッセージ -->

--- a/workers/email-receiver/src/index.ts
+++ b/workers/email-receiver/src/index.ts
@@ -3,13 +3,13 @@ import PostalMime from "postal-mime";
 export interface Env {
   /** 本番 ingest エンドポイント (notify.ippoan.org 用) */
   INGEST_ENDPOINT: string;
-  /** 本番 KV namespace (tenant-{slug} → plaintext ingest_key) */
-  INGEST_KEYS_KV: KVNamespace;
+  /** 本番 backend と共有する shared secret (wrangler secret put NOTIFY_WORKER_SECRET) */
+  NOTIFY_WORKER_SECRET: string;
 
   /** staging ingest エンドポイント (notify-staging.ippoan.org 用、任意) */
   INGEST_ENDPOINT_STAGING?: string;
-  /** staging KV namespace (任意) */
-  INGEST_KEYS_KV_STAGING?: KVNamespace;
+  /** staging backend と共有する shared secret (任意、staging host を受ける時のみ必要) */
+  NOTIFY_WORKER_SECRET_STAGING?: string;
 
   /** 本番ホスト名 (デフォルト notify.ippoan.org) */
   PROD_HOST?: string;
@@ -22,20 +22,40 @@ const MAX_ATTACHMENTS = 20;
 
 interface RouteTarget {
   endpoint: string;
-  kv: KVNamespace;
+  secret: string;
 }
 
 export function pickRoute(host: string, env: Env): RouteTarget | null {
   const prodHost = (env.PROD_HOST ?? "notify.ippoan.org").toLowerCase();
   const stagingHost = (env.STAGING_HOST ?? "notify-staging.ippoan.org").toLowerCase();
   const h = host.toLowerCase();
-  if (h === prodHost) {
-    return { endpoint: env.INGEST_ENDPOINT, kv: env.INGEST_KEYS_KV };
+  if (h === prodHost && env.INGEST_ENDPOINT && env.NOTIFY_WORKER_SECRET) {
+    return { endpoint: env.INGEST_ENDPOINT, secret: env.NOTIFY_WORKER_SECRET };
   }
-  if (h === stagingHost && env.INGEST_ENDPOINT_STAGING && env.INGEST_KEYS_KV_STAGING) {
-    return { endpoint: env.INGEST_ENDPOINT_STAGING, kv: env.INGEST_KEYS_KV_STAGING };
+  if (
+    h === stagingHost &&
+    env.INGEST_ENDPOINT_STAGING &&
+    env.NOTIFY_WORKER_SECRET_STAGING
+  ) {
+    return {
+      endpoint: env.INGEST_ENDPOINT_STAGING,
+      secret: env.NOTIFY_WORKER_SECRET_STAGING,
+    };
   }
   return null;
+}
+
+/**
+ * `tenant-{slug}` 形式の local-part から slug を抜き出す。
+ * - `tenant-acme` → `acme`
+ * - `tenant-` (空 slug) → null
+ * - `acme` (プレフィクス無し) → null
+ */
+export function extractTenantSlug(localPart: string): string | null {
+  const PREFIX = "tenant-";
+  if (!localPart.startsWith(PREFIX)) return null;
+  const slug = localPart.slice(PREFIX.length).trim();
+  return slug.length > 0 ? slug : null;
 }
 
 export default {
@@ -47,14 +67,16 @@ export default {
       return;
     }
 
-    // host → (endpoint, KV) を選択。未対応 host は silent drop。
+    // host → (endpoint, secret) を選択。未対応 host は silent drop。
     const route = pickRoute(host, env);
     if (!route) {
       return;
     }
 
-    const ingestKey = await route.kv.get(localPart);
-    if (!ingestKey) {
+    // local-part `tenant-{slug}` から slug を抽出。バウンスは From 偽装
+    // で第三者に送られうるので silent drop。
+    const tenantSlug = extractTenantSlug(localPart);
+    if (!tenantSlug) {
       return;
     }
 
@@ -97,6 +119,7 @@ export default {
     }
 
     const payload = {
+      tenant_slug: tenantSlug,
       from: parsed.from?.address ?? null,
       subject: parsed.subject ?? null,
       body_text: parsed.text ?? null,
@@ -111,7 +134,7 @@ export default {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Ingest-Key": ingestKey,
+          "X-Worker-Secret": route.secret,
         },
         body: JSON.stringify(payload),
       });

--- a/workers/email-receiver/tests/index.test.ts
+++ b/workers/email-receiver/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import worker, { pickRoute, uint8ArrayToBase64 } from "../src/index";
+import worker, { extractTenantSlug, pickRoute, uint8ArrayToBase64 } from "../src/index";
 
 function makeMessage(overrides: Partial<{
   to: string;
@@ -35,40 +35,51 @@ function makeMessage(overrides: Partial<{
   } as unknown as ForwardableEmailMessage & { setReject: typeof setReject };
 }
 
-function makeKv(value: string | null = "test-ingest-key") {
-  return { get: vi.fn().mockResolvedValue(value) } as unknown as KVNamespace;
-}
-
 function makeEnv(overrides: {
   prodEndpoint?: string;
-  prodKvValue?: string | null;
+  prodSecret?: string;
   stagingEndpoint?: string;
-  stagingKvValue?: string | null;
+  stagingSecret?: string;
 } = {}) {
-  // 注: ?? は null も default にしてしまうので、undefined のみ default 扱いにする
-  const prodVal = "prodKvValue" in overrides ? overrides.prodKvValue! : "test-ingest-key";
-  const stagingVal = "stagingKvValue" in overrides ? overrides.stagingKvValue! : "test-staging-key";
   return {
     INGEST_ENDPOINT: overrides.prodEndpoint ?? "https://prod.invalid/api/notify/ingest",
-    INGEST_KEYS_KV: makeKv(prodVal),
+    NOTIFY_WORKER_SECRET: overrides.prodSecret ?? "PROD_SECRET",
     INGEST_ENDPOINT_STAGING: overrides.stagingEndpoint ?? "https://staging.invalid/api/notify/ingest",
-    INGEST_KEYS_KV_STAGING: makeKv(stagingVal),
+    NOTIFY_WORKER_SECRET_STAGING: overrides.stagingSecret ?? "STAGING_SECRET",
   };
 }
+
+describe("extractTenantSlug", () => {
+  it("extracts slug from valid local-part", () => {
+    expect(extractTenantSlug("tenant-acme")).toBe("acme");
+    expect(extractTenantSlug("tenant-some-long-slug")).toBe("some-long-slug");
+  });
+
+  it("returns null for empty slug", () => {
+    expect(extractTenantSlug("tenant-")).toBeNull();
+    expect(extractTenantSlug("tenant-   ")).toBeNull();
+  });
+
+  it("returns null without prefix", () => {
+    expect(extractTenantSlug("acme")).toBeNull();
+    expect(extractTenantSlug("info")).toBeNull();
+    expect(extractTenantSlug("")).toBeNull();
+  });
+});
 
 describe("pickRoute", () => {
   it("routes notify.ippoan.org to prod", () => {
     const env = makeEnv();
     const r = pickRoute("notify.ippoan.org", env as any);
     expect(r?.endpoint).toBe("https://prod.invalid/api/notify/ingest");
-    expect(r?.kv).toBe(env.INGEST_KEYS_KV);
+    expect(r?.secret).toBe("PROD_SECRET");
   });
 
   it("routes notify-staging.ippoan.org to staging", () => {
     const env = makeEnv();
     const r = pickRoute("notify-staging.ippoan.org", env as any);
     expect(r?.endpoint).toBe("https://staging.invalid/api/notify/ingest");
-    expect(r?.kv).toBe(env.INGEST_KEYS_KV_STAGING);
+    expect(r?.secret).toBe("STAGING_SECRET");
   });
 
   it("returns null for unknown host", () => {
@@ -77,11 +88,24 @@ describe("pickRoute", () => {
     expect(pickRoute("evil.example.com", env as any)).toBeNull();
   });
 
-  it("staging routing requires both env vars", () => {
+  it("prod routing requires both endpoint and secret", () => {
+    const env: any = {
+      INGEST_ENDPOINT: "",
+      NOTIFY_WORKER_SECRET: "x",
+    };
+    expect(pickRoute("notify.ippoan.org", env)).toBeNull();
+    const env2: any = {
+      INGEST_ENDPOINT: "https://prod.invalid",
+      NOTIFY_WORKER_SECRET: "",
+    };
+    expect(pickRoute("notify.ippoan.org", env2)).toBeNull();
+  });
+
+  it("staging routing requires both endpoint and secret", () => {
     const env: any = {
       INGEST_ENDPOINT: "https://prod.invalid",
-      INGEST_KEYS_KV: makeKv(),
-      // INGEST_ENDPOINT_STAGING / INGEST_KEYS_KV_STAGING 未設定
+      NOTIFY_WORKER_SECRET: "x",
+      // INGEST_ENDPOINT_STAGING / NOTIFY_WORKER_SECRET_STAGING 未設定
     };
     expect(pickRoute("notify-staging.ippoan.org", env)).toBeNull();
   });
@@ -89,9 +113,9 @@ describe("pickRoute", () => {
   it("respects PROD_HOST / STAGING_HOST overrides", () => {
     const env: any = {
       INGEST_ENDPOINT: "https://prod.invalid",
-      INGEST_KEYS_KV: makeKv(),
+      NOTIFY_WORKER_SECRET: "p",
       INGEST_ENDPOINT_STAGING: "https://stg.invalid",
-      INGEST_KEYS_KV_STAGING: makeKv(),
+      NOTIFY_WORKER_SECRET_STAGING: "s",
       PROD_HOST: "mail.example.com",
       STAGING_HOST: "mail-stg.example.com",
     };
@@ -140,9 +164,15 @@ describe("email worker", () => {
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
-  it("silently drops when prod KV has no key for tenant", async () => {
-    const msg = makeMessage();
-    await worker.email(msg, makeEnv({ prodKvValue: null }) as any, {} as ExecutionContext);
+  it("silently drops when local-part lacks tenant- prefix", async () => {
+    const msg = makeMessage({ to: "info@notify.ippoan.org" });
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
+    expect(msg.setReject).not.toHaveBeenCalled();
+  });
+
+  it("silently drops when local-part is just the prefix with empty slug", async () => {
+    const msg = makeMessage({ to: "tenant-@notify.ippoan.org" });
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
@@ -173,34 +203,40 @@ describe("email worker", () => {
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
-  it("forwards prod email to prod ingest endpoint with prod key", async () => {
+  it("forwards prod email with tenant_slug + prod secret", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(null, { status: 201 }));
 
     const msg = makeMessage({ to: "tenant-acme@notify.ippoan.org" });
-    const env = makeEnv({ prodKvValue: "PROD_KEY" });
-    await worker.email(msg, env as any, {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
 
     expect(msg.setReject).not.toHaveBeenCalled();
     const [url, init] = fetchSpy.mock.calls[0]!;
     expect(url).toBe("https://prod.invalid/api/notify/ingest");
-    expect((init as RequestInit).headers).toMatchObject({ "X-Ingest-Key": "PROD_KEY" });
+    expect((init as RequestInit).headers).toMatchObject({
+      "X-Worker-Secret": "PROD_SECRET",
+    });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.tenant_slug).toBe("acme");
+    expect(body.attachments).toHaveLength(1);
+    expect(body.from).toBe("sender@example.com");
   });
 
-  it("forwards staging email to staging ingest endpoint with staging key", async () => {
+  it("forwards staging email with staging secret", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(null, { status: 201 }));
 
     const msg = makeMessage({ to: "tenant-acme@notify-staging.ippoan.org" });
-    const env = makeEnv({ stagingKvValue: "STAGING_KEY" });
-    await worker.email(msg, env as any, {} as ExecutionContext);
+    await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
 
     expect(msg.setReject).not.toHaveBeenCalled();
     const [url, init] = fetchSpy.mock.calls[0]!;
     expect(url).toBe("https://staging.invalid/api/notify/ingest");
-    expect((init as RequestInit).headers).toMatchObject({ "X-Ingest-Key": "STAGING_KEY" });
+    expect((init as RequestInit).headers).toMatchObject({
+      "X-Worker-Secret": "STAGING_SECRET",
+    });
   });
 
   it("rejects when ingest endpoint returns non-OK", async () => {

--- a/workers/email-receiver/wrangler.toml
+++ b/workers/email-receiver/wrangler.toml
@@ -5,24 +5,22 @@ compatibility_flags = ["nodejs_compat"]
 account_id = "24b45709d060d957340180e995f0d373"
 
 # 本番 Worker は zone catch-all で *@ippoan.org を全て受け、host で分岐:
-#   tenant-{slug}@notify.ippoan.org         → INGEST_KEYS_KV (prod) + INGEST_ENDPOINT
-#   tenant-{slug}@notify-staging.ippoan.org → INGEST_KEYS_KV_STAGING + INGEST_ENDPOINT_STAGING
-# それ以外の host (例: random@ippoan.org) は silent drop。
+#   tenant-{slug}@notify.ippoan.org         → INGEST_ENDPOINT + NOTIFY_WORKER_SECRET (prod)
+#   tenant-{slug}@notify-staging.ippoan.org → INGEST_ENDPOINT_STAGING + NOTIFY_WORKER_SECRET_STAGING
+# それ以外の host / 不正な local-part (= "tenant-{slug}" 形式でない) は silent drop。
+#
+# tenant 識別は body の `tenant_slug` で backend が `tenants.slug` から解決する。
+# 認証は shared secret (NOTIFY_WORKER_SECRET) で経路保護のみ。
+#
+# 必須 secret (デプロイ前に投入):
+#   wrangler secret put NOTIFY_WORKER_SECRET           # prod 値 (Secret Manager: notify-worker-secret)
+#   wrangler secret put NOTIFY_WORKER_SECRET_STAGING   # staging 値 (Secret Manager: notify-worker-secret-staging)
 
 [vars]
 INGEST_ENDPOINT = "https://alc-api.ippoan.org/api/notify/ingest"
 INGEST_ENDPOINT_STAGING = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/notify/ingest"
 PROD_HOST = "notify.ippoan.org"
 STAGING_HOST = "notify-staging.ippoan.org"
-
-# テナントごとの ingest_key を保持 (key=local-part, value=plaintext key)
-[[kv_namespaces]]
-binding = "INGEST_KEYS_KV"
-id = "3339456a3c0343c99e6114dcf9f70efb"
-
-[[kv_namespaces]]
-binding = "INGEST_KEYS_KV_STAGING"
-id = "7f1e4c04825148df9d4b9443ccee43c8"
 
 # staging Worker (notify-email-receiver-staging) は CI 都合で deploy はされるが
 # Email Routing の catch-all は1つしか持てないので実質受信しない。
@@ -34,11 +32,3 @@ name = "notify-email-receiver-staging"
 INGEST_ENDPOINT = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/notify/ingest"
 PROD_HOST = "notify-staging.ippoan.org"
 STAGING_HOST = "notify-staging.ippoan.org"
-
-[[env.staging.kv_namespaces]]
-binding = "INGEST_KEYS_KV"
-id = "7f1e4c04825148df9d4b9443ccee43c8"
-
-[[env.staging.kv_namespaces]]
-binding = "INGEST_KEYS_KV_STAGING"
-id = "7f1e4c04825148df9d4b9443ccee43c8"


### PR DESCRIPTION
Phase A counterpart of rust-alc-api#294.

Email Worker drops per-tenant KV lookup. Tenant is identified by body's tenant_slug (extracted from the local-part `tenant-{slug}`), and Worker→backend authentication uses a single shared secret per host.

## What changes

- src: extractTenantSlug() + pickRoute() picks (endpoint, secret) by host (prod vs staging)
- wrangler.toml: drop INGEST_KEYS_KV bindings; document the two required secrets
- tests: 24 passing — slug extraction, host routing, secret selection, silent-drop paths, full ingest forward
- settings.vue: Email 受信設定 simplified to inbound-address display only (ingest_key UI removed since the backend table is dropped in rust-alc-api#294)

## Out-of-band before deploy

User runs:

```
wrangler secret put NOTIFY_WORKER_SECRET            # prod, copy from gcloud secrets versions access latest --secret=notify-worker-secret
wrangler secret put NOTIFY_WORKER_SECRET_STAGING    # staging, from notify-worker-secret-staging
```

Both must match the Cloud Run env vars now wired in rust-alc-api#294.

## Test plan

- [ ] CI green
- [ ] Worker secrets set via wrangler
- [ ] Send a test email to tenant-<slug>@notify-staging.ippoan.org → notify_documents row created