### PR TITLE
fix(settings): read flat me.tenant_slug

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -215,10 +215,11 @@ const ingestEmailAddress = computed(() => {
 
 async function loadTenantSlug() {
   try {
-    const me = await apiFetch<{ tenant?: { slug?: string } }>('/auth/me')
-    tenantSlug.value = me?.tenant?.slug ?? ''
+    // /auth/me は flat な tenant_slug を返す (rust-alc-api#295)
+    const me = await apiFetch<{ tenant_slug?: string }>('/auth/me')
+    tenantSlug.value = me?.tenant_slug ?? ''
   } catch {
-    // /auth/me が無いテナントは tenantId をそのまま使う
+    // /auth/me が呼べないテナントは tenant_id をフォールバック表示 (アドレス組み立てには使えないが UI 上の表示崩れを防ぐ)
     tenantSlug.value = orgId.value ?? ''
   }
 }


### PR DESCRIPTION
rust-alc-api#295 (PR pending) で /auth/me に flat な tenant_slug が追加された。フロントは元々ネスト形式 `me.tenant.slug` を期待していたため永遠に空 → 「(テナント情報取得中...)」のままだった。

## Test plan
- [ ] /settings の Email 受信設定に `tenant-{slug}@notify.ippoan.org` が表示される (rust-alc-api#295 が staging deploy された後)