### PR TITLE
refactor(notify): tenant_short_id

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -200,7 +200,7 @@ async function remove() {
 }
 
 // ===== Email 受信設定 =====
-const tenantSlug = ref<string>('')
+const tenantShortId = ref<string>('')
 
 const ingestEmailDomain = computed(() => {
   // 本番判定: apiBase ホスト名から推定。Cloudflare Email Routing 側の設定と整合させる。
@@ -209,24 +209,23 @@ const ingestEmailDomain = computed(() => {
 })
 
 const ingestEmailAddress = computed(() => {
-  if (!tenantSlug.value) return ''
-  return `tenant-${tenantSlug.value}@${ingestEmailDomain.value}`
+  if (!tenantShortId.value) return ''
+  return `tenant-${tenantShortId.value}@${ingestEmailDomain.value}`
 })
 
-async function loadTenantSlug() {
+async function loadTenantShortId() {
   try {
-    // /auth/me は flat な tenant_slug を返す (rust-alc-api#295)
-    const me = await apiFetch<{ tenant_slug?: string }>('/auth/me')
-    tenantSlug.value = me?.tenant_slug ?? ''
+    // /auth/me は tenant_short_id (8 文字 hex、NOT NULL) を返す (rust-alc-api#296)
+    const me = await apiFetch<{ tenant_short_id?: string }>('/auth/me')
+    tenantShortId.value = me?.tenant_short_id ?? ''
   } catch {
-    // /auth/me が呼べないテナントは tenant_id をフォールバック表示 (アドレス組み立てには使えないが UI 上の表示崩れを防ぐ)
-    tenantSlug.value = orgId.value ?? ''
+    tenantShortId.value = ''
   }
 }
 
 onMounted(async () => {
   await load()
-  await loadTenantSlug()
+  await loadTenantShortId()
 })
 </script>
 

--- a/workers/email-receiver/src/index.ts
+++ b/workers/email-receiver/src/index.ts
@@ -46,16 +46,20 @@ export function pickRoute(host: string, env: Env): RouteTarget | null {
 }
 
 /**
- * `tenant-{slug}` 形式の local-part から slug を抜き出す。
- * - `tenant-acme` → `acme`
- * - `tenant-` (空 slug) → null
- * - `acme` (プレフィクス無し) → null
+ * `tenant-{short_id}` 形式の local-part から `tenants.short_id` (8 文字 hex) を抜き出す。
+ * - `tenant-1925a8e1` → `1925a8e1`
+ * - `tenant-` (空) → null
+ * - `1925a8e1` (プレフィクス無し) → null
+ *
+ * 形式が変でも backend が `tenants.short_id = $1` で 0 件にすれば silent drop に
+ * なるので、ここでは長さの厳密チェックはしない (tenant-default 等の
+ * 旧 slug 形式も後方互換で受け付け、backend が見つけられなければ 404)。
  */
-export function extractTenantSlug(localPart: string): string | null {
+export function extractTenantShortId(localPart: string): string | null {
   const PREFIX = "tenant-";
   if (!localPart.startsWith(PREFIX)) return null;
-  const slug = localPart.slice(PREFIX.length).trim();
-  return slug.length > 0 ? slug : null;
+  const id = localPart.slice(PREFIX.length).trim();
+  return id.length > 0 ? id : null;
 }
 
 export default {
@@ -73,10 +77,10 @@ export default {
       return;
     }
 
-    // local-part `tenant-{slug}` から slug を抽出。バウンスは From 偽装
+    // local-part `tenant-{short_id}` から短縮 ID を抽出。バウンスは From 偽装
     // で第三者に送られうるので silent drop。
-    const tenantSlug = extractTenantSlug(localPart);
-    if (!tenantSlug) {
+    const tenantShortId = extractTenantShortId(localPart);
+    if (!tenantShortId) {
       return;
     }
 
@@ -119,7 +123,7 @@ export default {
     }
 
     const payload = {
-      tenant_slug: tenantSlug,
+      tenant_short_id: tenantShortId,
       from: parsed.from?.address ?? null,
       subject: parsed.subject ?? null,
       body_text: parsed.text ?? null,

--- a/workers/email-receiver/tests/index.test.ts
+++ b/workers/email-receiver/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import worker, { extractTenantSlug, pickRoute, uint8ArrayToBase64 } from "../src/index";
+import worker, { extractTenantShortId, pickRoute, uint8ArrayToBase64 } from "../src/index";
 
 function makeMessage(overrides: Partial<{
   to: string;
@@ -49,21 +49,23 @@ function makeEnv(overrides: {
   };
 }
 
-describe("extractTenantSlug", () => {
-  it("extracts slug from valid local-part", () => {
-    expect(extractTenantSlug("tenant-acme")).toBe("acme");
-    expect(extractTenantSlug("tenant-some-long-slug")).toBe("some-long-slug");
+describe("extractTenantShortId", () => {
+  it("extracts short_id from valid local-part", () => {
+    expect(extractTenantShortId("tenant-1925a8e1")).toBe("1925a8e1");
+    expect(extractTenantShortId("tenant-deadbeef")).toBe("deadbeef");
+    // 形式チェックは backend に任せるので、UUID 以外でも raw に通す
+    expect(extractTenantShortId("tenant-some-long-slug")).toBe("some-long-slug");
   });
 
-  it("returns null for empty slug", () => {
-    expect(extractTenantSlug("tenant-")).toBeNull();
-    expect(extractTenantSlug("tenant-   ")).toBeNull();
+  it("returns null for empty short_id", () => {
+    expect(extractTenantShortId("tenant-")).toBeNull();
+    expect(extractTenantShortId("tenant-   ")).toBeNull();
   });
 
   it("returns null without prefix", () => {
-    expect(extractTenantSlug("acme")).toBeNull();
-    expect(extractTenantSlug("info")).toBeNull();
-    expect(extractTenantSlug("")).toBeNull();
+    expect(extractTenantShortId("1925a8e1")).toBeNull();
+    expect(extractTenantShortId("info")).toBeNull();
+    expect(extractTenantShortId("")).toBeNull();
   });
 });
 
@@ -203,12 +205,12 @@ describe("email worker", () => {
     expect(msg.setReject).not.toHaveBeenCalled();
   });
 
-  it("forwards prod email with tenant_slug + prod secret", async () => {
+  it("forwards prod email with tenant_short_id + prod secret", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(null, { status: 201 }));
 
-    const msg = makeMessage({ to: "tenant-acme@notify.ippoan.org" });
+    const msg = makeMessage({ to: "tenant-1925a8e1@notify.ippoan.org" });
     await worker.email(msg, makeEnv() as any, {} as ExecutionContext);
 
     expect(msg.setReject).not.toHaveBeenCalled();
@@ -218,7 +220,7 @@ describe("email worker", () => {
       "X-Worker-Secret": "PROD_SECRET",
     });
     const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.tenant_slug).toBe("acme");
+    expect(body.tenant_short_id).toBe("1925a8e1");
     expect(body.attachments).toHaveLength(1);
     expect(body.from).toBe("sender@example.com");
   });


### PR DESCRIPTION
rust-alc-api#296 で tenants.short_id (UNIQUE, NOT NULL) が追加された。メール ingest 経路 + 受信用アドレス UI をそちらに切り替える。Google OAuth 自動サインアップで slug が NULL のままになっていたケース (/settings の「(テナント情報取得中...)」永続) が解消する。

## What changes
- Worker: extractTenantSlug→extractTenantShortId、body field tenant_slug→tenant_short_id、tests 24 件 pass
- settings.vue: me.tenant_slug→me.tenant_short_id

## Test plan
- [ ] CI green
- [ ] rust-alc-api#296 merge + staging deploy 後、再ログインで /settings に `tenant-{8chars}@notify-staging.ippoan.org` が出る
- [ ] そのアドレスに添付付きメール送信 → 受信メール一覧に表示される