### PR TITLE
feat(notify): 配信先個別選択 + /documents/[id] 詳細ページ + 一覧日本語化

### DIFF
--- a/app/components/DistributeModal.vue
+++ b/app/components/DistributeModal.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+const { apiFetch } = useApi()
+
+interface Recipient {
+  id: string
+  name: string
+  provider: 'line' | 'lineworks'
+  enabled: boolean
+}
+
+const props = defineProps<{
+  documentId: string
+  fileName: string | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+  distributed: [{ sent: number; failed: number; total: number }]
+}>()
+
+const recipients = ref<Recipient[]>([])
+const selected = ref<Set<string>>(new Set())
+const loading = ref(true)
+const loadError = ref('')
+const sending = ref(false)
+const sendError = ref('')
+
+const enabledRecipients = computed(() => recipients.value.filter(r => r.enabled))
+
+async function load() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    recipients.value = await apiFetch('/notify/recipients')
+  } catch (e: any) {
+    loadError.value = e.message || String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function toggle(id: string) {
+  const next = new Set(selected.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selected.value = next
+}
+
+function selectAll() {
+  selected.value = new Set(enabledRecipients.value.map(r => r.id))
+}
+
+function clearAll() {
+  selected.value = new Set()
+}
+
+async function submit() {
+  if (selected.value.size === 0) return
+  sending.value = true
+  sendError.value = ''
+  try {
+    const result = await apiFetch<{ sent: number; failed: number; total: number }>(
+      `/notify/documents/${props.documentId}/distribute`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ target: { recipient_ids: [...selected.value] } }),
+      },
+    )
+    emit('distributed', result)
+    emit('close')
+  } catch (e: any) {
+    sendError.value = e.message || String(e)
+  } finally {
+    sending.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+       @click.self="emit('close')">
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
+      <!-- Header -->
+      <div class="px-5 py-3 border-b flex items-center justify-between">
+        <h3 class="font-bold">配信先を選択</h3>
+        <button @click="emit('close')" class="text-gray-400 hover:text-gray-600 text-xl leading-none">×</button>
+      </div>
+
+      <!-- Body -->
+      <div class="px-5 py-4 overflow-y-auto flex-1">
+        <div class="text-xs text-gray-500 mb-3 truncate">📄 {{ fileName ?? '(無名)' }}</div>
+
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-sm text-gray-600">
+            {{ selected.size }} / {{ enabledRecipients.length }} 人 選択中
+          </span>
+          <div class="flex gap-2">
+            <button @click="selectAll" type="button"
+                    :disabled="enabledRecipients.length === 0"
+                    class="px-2 py-1 text-xs border rounded hover:bg-gray-50 disabled:opacity-50">
+              全選択
+            </button>
+            <button @click="clearAll" type="button"
+                    :disabled="selected.size === 0"
+                    class="px-2 py-1 text-xs border rounded hover:bg-gray-50 disabled:opacity-50">
+              全解除
+            </button>
+          </div>
+        </div>
+
+        <div v-if="loading" class="text-sm text-gray-500 py-6 text-center">読み込み中...</div>
+        <div v-else-if="loadError" class="bg-red-50 border border-red-200 rounded p-3 text-red-700 text-sm">
+          {{ loadError }}
+        </div>
+        <div v-else-if="enabledRecipients.length === 0"
+             class="text-sm text-gray-500 py-6 text-center">
+          有効な受信者がいません。
+          <NuxtLink to="/recipients" class="text-blue-600 hover:underline">受信者管理</NuxtLink>
+          から登録してください。
+        </div>
+        <ul v-else class="divide-y border rounded">
+          <li v-for="r in enabledRecipients" :key="r.id"
+              class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+              @click="toggle(r.id)">
+            <input type="checkbox" :checked="selected.has(r.id)"
+                   @click.stop="toggle(r.id)"
+                   class="w-4 h-4" />
+            <span class="flex-1 text-sm">{{ r.name }}</span>
+            <span :class="r.provider === 'line' ? 'text-green-600' : 'text-blue-600'"
+                  class="text-xs font-medium">
+              {{ r.provider === 'line' ? 'LINE' : 'LINE WORKS' }}
+            </span>
+          </li>
+        </ul>
+
+        <div v-if="sendError" class="mt-3 bg-red-50 border border-red-200 rounded p-3 text-red-700 text-sm">
+          {{ sendError }}
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="px-5 py-3 border-t flex items-center justify-end gap-2">
+        <button @click="emit('close')" type="button"
+                class="px-4 py-2 text-sm border rounded hover:bg-gray-50">
+          キャンセル
+        </button>
+        <button @click="submit" type="button"
+                :disabled="sending || selected.size === 0"
+                class="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+          {{ sending ? '配信中...' : `配信 (${selected.size} 人)` }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { useAuth } from '@ippoan/auth-client'
+
+const route = useRoute()
+const { apiFetch } = useApi()
+const { token, orgId } = useAuth()
+
+const documentId = computed(() => String(route.params.id))
+
+interface NotifyDocument {
+  id: string
+  email_message_id: string | null
+  file_name: string | null
+  file_size_bytes: number | null
+  extracted_title: string | null
+  extracted_summary: string | null
+  extraction_status: string
+  distribution_status: string
+  created_at: string
+}
+
+interface Delivery {
+  id: string
+  recipient_id: string
+  recipient_name: string
+  provider: string
+  status: string
+  sent_at: string | null
+  read_at: string | null
+  triggered_by_user_id: string | null
+  triggered_by_name: string | null
+  triggered_by_email: string | null
+  created_at: string
+}
+
+interface DocumentResponse {
+  document: NotifyDocument
+  deliveries: Delivery[]
+}
+
+const document = ref<NotifyDocument | null>(null)
+const deliveries = ref<Delivery[]>([])
+const loading = ref(true)
+const error = ref('')
+const showDistribute = ref(false)
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await apiFetch<DocumentResponse>(`/notify/documents/${documentId.value}`)
+    document.value = res.document
+    deliveries.value = res.deliveries
+  } catch (e: any) {
+    error.value = e.message || String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function downloadDoc() {
+  if (!document.value) return
+  try {
+    const config = useRuntimeConfig()
+    const apiBase = config.public.apiBase as string
+    const headers: Record<string, string> = {}
+    if (token.value) {
+      headers.Authorization = `Bearer ${token.value}`
+    } else if (orgId.value) {
+      headers['X-Tenant-ID'] = orgId.value
+    }
+    const res = await fetch(`${apiBase}/api/notify/documents/${document.value.id}/download`, { headers })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = window.document.createElement('a')
+    a.href = url
+    a.download = document.value.file_name ?? 'attachment'
+    window.document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  } catch (e: any) {
+    alert(`ダウンロード失敗: ${e.message ?? e}`)
+  }
+}
+
+async function onDistributed(result: { sent: number; failed: number; total: number }) {
+  alert(`配信完了: 成功 ${result.sent} / 失敗 ${result.failed} / 合計 ${result.total}`)
+  await load()
+}
+
+function formatSize(bytes: number | null): string {
+  if (!bytes) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function formatDate(s: string | null): string {
+  if (!s) return '-'
+  return new Date(s).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function deliveryStatusLabel(status: string): { label: string; cls: string } {
+  switch (status) {
+    case 'sent':
+      return { label: '送信済', cls: 'bg-green-100 text-green-700' }
+    case 'failed':
+      return { label: '失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return { label: '未送信', cls: 'bg-gray-100 text-gray-700' }
+    default:
+      return { label: status, cls: 'bg-gray-100 text-gray-700' }
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="mb-4">
+      <NuxtLink v-if="document?.email_message_id"
+                :to="`/emails/${document.email_message_id}`"
+                class="text-sm text-blue-600 hover:underline">
+        ← メール詳細へ
+      </NuxtLink>
+      <NuxtLink v-else to="/emails" class="text-sm text-blue-600 hover:underline">
+        ← 受信メール一覧
+      </NuxtLink>
+    </div>
+
+    <div v-if="loading" class="text-gray-500 py-10 text-center">読み込み中...</div>
+    <div v-else-if="error" class="bg-red-50 border border-red-200 text-red-700 p-3 rounded">
+      {{ error }}
+    </div>
+    <div v-else-if="document">
+      <!-- ヘッダ -->
+      <div class="bg-white border rounded p-4 mb-4">
+        <div class="flex items-start justify-between">
+          <div class="flex-1 min-w-0">
+            <h2 class="text-lg font-bold truncate">📄 {{ document.file_name ?? '(無名)' }}</h2>
+            <div class="text-xs text-gray-500 mt-1">
+              {{ formatSize(document.file_size_bytes) }} · 受信 {{ formatDate(document.created_at) }}
+            </div>
+          </div>
+          <div class="flex gap-2 flex-shrink-0">
+            <button @click="downloadDoc"
+                    class="text-sm bg-gray-100 hover:bg-gray-200 px-3 py-1.5 rounded">
+              ダウンロード
+            </button>
+            <button @click="showDistribute = true"
+                    class="text-sm bg-blue-600 text-white hover:bg-blue-700 px-3 py-1.5 rounded">
+              配信
+            </button>
+          </div>
+        </div>
+
+        <div v-if="document.extracted_title || document.extracted_summary"
+             class="mt-3 pt-3 border-t text-sm text-gray-700">
+          <div v-if="document.extracted_title" class="font-medium">
+            {{ document.extracted_title }}
+          </div>
+          <div v-if="document.extracted_summary" class="mt-1 text-gray-600 whitespace-pre-wrap">
+            {{ document.extracted_summary }}
+          </div>
+        </div>
+      </div>
+
+      <!-- 配信履歴 -->
+      <div class="bg-white border rounded p-4">
+        <h3 class="text-sm font-bold mb-3">配信履歴</h3>
+        <div v-if="deliveries.length === 0" class="text-sm text-gray-400">未配信</div>
+        <table v-else class="w-full text-xs">
+          <thead class="text-gray-500">
+            <tr>
+              <th class="text-left py-1">送信日時</th>
+              <th class="text-left py-1">実行者</th>
+              <th class="text-left py-1">受信者</th>
+              <th class="text-left py-1">手段</th>
+              <th class="text-left py-1">状況</th>
+              <th class="text-left py-1">既読</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="d in deliveries" :key="d.id" class="border-t">
+              <td class="py-1 text-gray-700">{{ formatDate(d.sent_at ?? d.created_at) }}</td>
+              <td class="py-1 text-gray-700">
+                {{ d.triggered_by_name || d.triggered_by_email || '-' }}
+              </td>
+              <td class="py-1 text-gray-900">{{ d.recipient_name }}</td>
+              <td class="py-1 text-gray-500">{{ d.provider }}</td>
+              <td class="py-1">
+                <span :class="['inline-block px-1.5 py-0.5 rounded', deliveryStatusLabel(d.status).cls]">
+                  {{ deliveryStatusLabel(d.status).label }}
+                </span>
+              </td>
+              <td class="py-1 text-gray-500">{{ d.read_at ? formatDate(d.read_at) : '-' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <DistributeModal v-if="showDistribute && document"
+                     :document-id="document.id"
+                     :file-name="document.file_name"
+                     @close="showDistribute = false"
+                     @distributed="onDistributed" />
+  </div>
+</template>

--- a/app/pages/emails/[id].vue
+++ b/app/pages/emails/[id].vue
@@ -50,8 +50,8 @@ const detail = ref<EmailDetail | null>(null)
 const deliveriesByDoc = ref<Record<string, Delivery[]>>({})
 const loading = ref(true)
 const error = ref('')
-const distributing = ref<Record<string, boolean>>({})
 const deleting = ref<Record<string, boolean>>({})
+const distributeTarget = ref<EmailDocument | null>(null)
 
 async function loadDetail() {
   loading.value = true
@@ -101,20 +101,13 @@ async function downloadDoc(doc: EmailDocument) {
   }
 }
 
-async function distribute(doc: EmailDocument) {
-  if (!confirm(`「${doc.file_name ?? 'ドキュメント'}」を全受信者に配信しますか?`)) return
-  distributing.value[doc.id] = true
-  try {
-    await apiFetch(`/notify/documents/${doc.id}/distribute`, {
-      method: 'POST',
-      body: JSON.stringify({ target: { all: true } }),
-    })
-    await loadDetail()
-  } catch (e: any) {
-    alert(`配信失敗: ${e.message ?? e}`)
-  } finally {
-    distributing.value[doc.id] = false
-  }
+function openDistribute(doc: EmailDocument) {
+  distributeTarget.value = doc
+}
+
+async function onDistributed(result: { sent: number; failed: number; total: number }) {
+  alert(`配信完了: 成功 ${result.sent} / 失敗 ${result.failed} / 合計 ${result.total}`)
+  await loadDetail()
 }
 
 async function deleteDoc(doc: EmailDocument) {
@@ -207,9 +200,9 @@ onMounted(loadDetail)
                     class="text-xs bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded">
               ダウンロード
             </button>
-            <button @click="distribute(doc)" :disabled="distributing[doc.id]"
-                    class="text-xs bg-blue-600 text-white hover:bg-blue-700 px-3 py-1 rounded disabled:opacity-50">
-              {{ distributing[doc.id] ? '配信中...' : '配信' }}
+            <button @click="openDistribute(doc)"
+                    class="text-xs bg-blue-600 text-white hover:bg-blue-700 px-3 py-1 rounded">
+              配信
             </button>
             <button @click="deleteDoc(doc)" :disabled="deleting[doc.id]"
                     class="text-xs bg-red-50 text-red-600 hover:bg-red-100 px-3 py-1 rounded disabled:opacity-50">
@@ -253,5 +246,11 @@ onMounted(loadDetail)
         <div v-else class="text-xs text-gray-400 mt-2">未配信</div>
       </div>
     </div>
+
+    <DistributeModal v-if="distributeTarget"
+                     :document-id="distributeTarget.id"
+                     :file-name="distributeTarget.file_name"
+                     @close="distributeTarget = null"
+                     @distributed="onDistributed" />
   </div>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,19 +1,57 @@
 <script setup lang="ts">
 const { apiFetch } = useApi()
 
-const documents = ref<any[]>([])
+interface NotifyDocument {
+  id: string
+  file_name: string | null
+  extracted_title: string | null
+  extracted_summary: string | null
+  source_sender: string | null
+  source_subject: string | null
+  extraction_status: string
+  distribution_status: string
+  created_at: string
+}
+
+const documents = ref<NotifyDocument[]>([])
 const loading = ref(true)
 const error = ref('')
 
 onMounted(async () => {
   try {
-    documents.value = await apiFetch('/notify/documents?limit=20')
+    documents.value = await apiFetch<NotifyDocument[]>('/notify/documents?limit=20')
   } catch (e: any) {
     error.value = e.message || String(e)
   } finally {
     loading.value = false
   }
 })
+
+function extractionBadge(status: string): { label: string; cls: string } {
+  switch (status) {
+    case 'completed':
+      return { label: '抽出済', cls: 'bg-green-100 text-green-700' }
+    case 'failed':
+      return { label: '抽出失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return { label: '抽出待ち', cls: 'bg-yellow-100 text-yellow-700' }
+    default:
+      return { label: status, cls: 'bg-gray-100 text-gray-600' }
+  }
+}
+
+function distributionBadge(status: string): { label: string; cls: string } {
+  switch (status) {
+    case 'completed':
+      return { label: '配信済', cls: 'bg-green-100 text-green-700' }
+    case 'in_progress':
+      return { label: '配信中', cls: 'bg-blue-100 text-blue-700' }
+    case 'failed':
+      return { label: '配信失敗', cls: 'bg-red-100 text-red-700' }
+    default:
+      return { label: '未配信', cls: 'bg-gray-100 text-gray-600' }
+  }
+}
 </script>
 
 <template>
@@ -25,34 +63,27 @@ onMounted(async () => {
     <div v-else-if="documents.length === 0" class="text-gray-400">ドキュメントはまだありません</div>
 
     <div v-else class="space-y-3">
-      <div v-for="doc in documents" :key="doc.id"
-           class="bg-white rounded-lg shadow p-4 border">
-        <div class="flex justify-between items-start">
-          <div>
-            <h3 class="font-semibold">{{ doc.extracted_title || doc.file_name || 'Untitled' }}</h3>
-            <p class="text-sm text-gray-500 mt-1">{{ doc.extracted_summary || doc.source_subject }}</p>
+      <NuxtLink v-for="doc in documents" :key="doc.id"
+                :to="`/documents/${doc.id}`"
+                class="block bg-white rounded-lg shadow p-4 border hover:bg-gray-50 transition">
+        <div class="flex justify-between items-start gap-3">
+          <div class="min-w-0 flex-1">
+            <h3 class="font-semibold truncate">{{ doc.extracted_title || doc.file_name || 'Untitled' }}</h3>
+            <p class="text-sm text-gray-500 mt-1 truncate">{{ doc.extracted_summary || doc.source_subject }}</p>
             <p class="text-xs text-gray-400 mt-1">
               {{ doc.source_sender }} · {{ new Date(doc.created_at).toLocaleString('ja-JP') }}
             </p>
           </div>
-          <div class="flex gap-2">
-            <span :class="{
-              'bg-yellow-100 text-yellow-700': doc.extraction_status === 'pending',
-              'bg-green-100 text-green-700': doc.extraction_status === 'completed',
-              'bg-red-100 text-red-700': doc.extraction_status === 'failed',
-            }" class="px-2 py-0.5 text-xs rounded-full">
-              {{ doc.extraction_status }}
+          <div class="flex gap-2 flex-shrink-0">
+            <span :class="['px-2 py-0.5 text-xs rounded-full', extractionBadge(doc.extraction_status).cls]">
+              {{ extractionBadge(doc.extraction_status).label }}
             </span>
-            <span :class="{
-              'bg-gray-100 text-gray-600': doc.distribution_status === 'pending',
-              'bg-blue-100 text-blue-700': doc.distribution_status === 'in_progress',
-              'bg-green-100 text-green-700': doc.distribution_status === 'completed',
-            }" class="px-2 py-0.5 text-xs rounded-full">
-              {{ doc.distribution_status }}
+            <span :class="['px-2 py-0.5 text-xs rounded-full', distributionBadge(doc.distribution_status).cls]">
+              {{ distributionBadge(doc.distribution_status).label }}
             </span>
           </div>
         </div>
-      </div>
+      </NuxtLink>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## 変更内容

### 1. 配信先の個別選択 UI (誤爆防止)
- 新規 `app/components/DistributeModal.vue` — 受信者を個別チェックボックスで選択 + 全選択/全解除 + 「配信 (N 人)」
- `app/pages/emails/[id].vue` の「配信」ボタンが confirm() ハードコード全員配信ではなく、modal を開く形に
- バック側 \`DistributeTarget { all, group_id, recipient_ids }\` は既に対応済 (rust-alc-api crates/alc-notify/src/distribute.rs)

### 2. /documents/[id] 詳細ページ新規追加
- 新規 `app/pages/documents/[id].vue` — ファイル名/サイズ/受信日時/抽出タイトル・サマリ/ダウンロード/再配信/配信履歴
- `/api/notify/read/{token}` のリダイレクト先 `/documents/{id}` がこれまで 404 だった (リンクから見れなかった)
- email_message_id があれば「← メール詳細へ」、無ければ「← 受信メール一覧」に戻る

### 3. ドキュメント一覧 (index) UX 改善
- `app/pages/index.vue` のステータスバッジを英語生値から日本語ラベルに
  - extraction_status: pending→抽出待ち / completed→抽出済 / failed→抽出失敗
  - distribution_status: pending→未配信 / in_progress→配信中 / completed→配信済 / failed→配信失敗
- 各行を NuxtLink 化 → クリックで /documents/{id} 詳細ページへ

## 動作確認
- /wt-quick + Cloudflare Quick Tunnel で本番 API に対して確認
- 実 LINE WORKS 受信者へ配信 → 既読まで記録された

## 後続
- rust-alc-api の render.sh に NOTIFY_FRONTEND_URL を投入する別 PR 必要 (現状未設定のため、本番の read URL は notify.example.com デフォルトに飛んでしまう)