### PR TITLE
feat: public viewer page for distributed PDFs

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import { useAuth, AuthToolbar } from '@ippoan/auth-client'
 
+const route = useRoute()
 const { isAuthenticated, loadFromStorage, consumeFragment, redirectToLogin } = useAuth()
 const runtimeConfig = useRuntimeConfig()
 const { apiFetch } = useApi()
+
+// `/v/...` は配信受信者向けの公開 viewer (ログイン不要)。
+// header / 認証ゲートを丸ごとスキップして NuxtPage だけを描画する。
+const isPublicView = computed(() => route.path.startsWith('/v/'))
 
 const lineLoginUrl = computed(() => {
   const apiBase = runtimeConfig.public.apiBase as string
@@ -73,7 +78,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-50">
+  <NuxtPage v-if="isPublicView" />
+  <div v-else class="min-h-screen bg-gray-50">
     <header class="bg-white shadow-sm border-b">
       <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
         <NuxtLink to="/" class="text-lg font-bold text-gray-800">📨 Notify</NuxtLink>

--- a/app/pages/v/[token].vue
+++ b/app/pages/v/[token].vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+// 配信受信者向けの公開 viewer ページ。ログイン不要。
+// /api/notify/read/{token} 経由で 302 redirect されてくる。
+//
+// ページ内で
+//   GET /api/notify/v/{token}      → メタデータ JSON
+//   <iframe src="...v/{token}/file"> → R2 inline PDF
+// を呼ぶ。
+
+const route = useRoute()
+const config = useRuntimeConfig()
+const apiBase = config.public.apiBase as string
+
+const token = computed(() => String(route.params.token))
+const fileUrl = computed(() => `${apiBase}/api/notify/v/${token.value}/file`)
+
+interface ViewMetadata {
+  file_name: string | null
+  file_size_bytes: number | null
+  source_subject: string | null
+  source_sender: string | null
+  source_received_at: string | null
+  expire_at: string
+}
+
+const meta = ref<ViewMetadata | null>(null)
+const status = ref<'loading' | 'ok' | 'gone' | 'not_found' | 'error'>('loading')
+
+const isPdf = computed(() => {
+  const name = meta.value?.file_name ?? ''
+  return name.toLowerCase().endsWith('.pdf')
+})
+
+function formatSize(bytes: number | null): string {
+  if (!bytes) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function formatDate(s: string | null): string {
+  if (!s) return ''
+  return new Date(s).toLocaleString('ja-JP', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+async function load() {
+  try {
+    const res = await fetch(`${apiBase}/api/notify/v/${token.value}`)
+    if (res.status === 410) { status.value = 'gone'; return }
+    if (res.status === 404) { status.value = 'not_found'; return }
+    if (!res.ok) { status.value = 'error'; return }
+    meta.value = await res.json()
+    status.value = 'ok'
+  } catch {
+    status.value = 'error'
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-50">
+    <!-- 上部バー -->
+    <header class="bg-white shadow-sm border-b sticky top-0 z-10">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
+        <div class="min-w-0 flex-1">
+          <div class="text-base sm:text-lg font-bold text-gray-800 truncate">
+            {{ meta?.file_name ?? '添付ファイル' }}
+          </div>
+          <div v-if="meta" class="text-xs text-gray-500 truncate">
+            <span v-if="meta.source_subject">{{ meta.source_subject }}</span>
+            <span v-if="meta.source_sender"> · {{ meta.source_sender }}</span>
+            <span v-if="meta.source_received_at"> · {{ formatDate(meta.source_received_at) }}</span>
+            <span v-if="meta.file_size_bytes"> · {{ formatSize(meta.file_size_bytes) }}</span>
+          </div>
+        </div>
+        <a v-if="status === 'ok'" :href="fileUrl" target="_blank" rel="noopener"
+           class="shrink-0 bg-blue-600 text-white text-sm font-medium px-4 py-2 rounded hover:bg-blue-700 whitespace-nowrap">
+          📄 開く
+        </a>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-4">
+      <div v-if="status === 'loading'" class="text-center py-20 text-gray-500">
+        読み込み中…
+      </div>
+      <div v-else-if="status === 'gone'" class="text-center py-20">
+        <div class="text-2xl mb-2">⏰</div>
+        <p class="text-gray-700">このリンクの有効期限が切れています。</p>
+        <p class="text-sm text-gray-500 mt-2">送信元にお問い合わせください。</p>
+      </div>
+      <div v-else-if="status === 'not_found'" class="text-center py-20">
+        <p class="text-gray-700">リンクが見つかりません。</p>
+      </div>
+      <div v-else-if="status === 'error'" class="text-center py-20">
+        <p class="text-gray-700">読み込みに失敗しました。</p>
+        <button @click="load" class="mt-3 bg-gray-100 hover:bg-gray-200 px-4 py-2 rounded text-sm">
+          再試行
+        </button>
+      </div>
+      <div v-else>
+        <!-- PDF: iframe で inline 表示 (デスクトップ向け、モバイルでも一部端末で表示) -->
+        <iframe v-if="isPdf" :src="fileUrl" class="w-full h-[80vh] bg-white border rounded shadow-sm"
+                title="PDF ビューア"></iframe>
+        <!-- 非 PDF (画像 / Office 等): 「開く」ボタンを大きく表示 -->
+        <div v-else class="text-center py-20">
+          <a :href="fileUrl" target="_blank" rel="noopener"
+             class="inline-block bg-blue-600 text-white text-lg font-medium px-8 py-4 rounded-lg hover:bg-blue-700">
+            📥 ファイルを開く
+          </a>
+        </div>
+
+        <!-- モバイル / iframe 未対応端末向け fallback ボタン -->
+        <div v-if="isPdf" class="mt-4 text-center sm:hidden">
+          <a :href="fileUrl" target="_blank" rel="noopener"
+             class="inline-block bg-blue-600 text-white text-base font-medium px-6 py-3 rounded-lg hover:bg-blue-700">
+            📄 PDF を別タブで開く
+          </a>
+          <p class="mt-2 text-xs text-gray-500">表示されない場合はこちらをタップ</p>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- `/v/[token]` 公開 viewer ページを新設。ログイン不要
- `app.vue` で `/v/...` パスは header / 認証ゲートを丸ごとスキップ
- PDF は `<iframe>` で inline 表示、モバイル fallback ボタンも併設

backend (rust-alc-api) PR #302 で `/api/notify/read/{token}` がこのページに 302 redirect する。

## 受信者の動線
1. LINE / LINE WORKS のメッセージ内リンクをタップ
2. backend `/api/notify/read/{token}` → 既読化 → 302 → `/v/{token}` (このページ)
3. ページがメタデータを取得 → iframe で PDF inline 表示
4. モバイルで iframe が描画されない場合は「📄 開く」ボタン (新タブで PDF)

## Test plan
- [x] vitest pass (既存テストに影響なし)
- [ ] CI: typecheck + vitest
- [ ] staging deploy 後、LINE 配信リンクから踏んで Android Chrome で inline 表示確認
- [ ] 410 / 404 表示確認