### PR TITLE
fix(viewer): hide iframe on mobile

### DIFF
--- a/app/pages/v/[token].vue
+++ b/app/pages/v/[token].vue
@@ -104,24 +104,24 @@ onMounted(load)
         </button>
       </div>
       <div v-else>
-        <!-- PDF: iframe で inline 表示 (デスクトップ向け、モバイルでも一部端末で表示) -->
-        <iframe v-if="isPdf" :src="fileUrl" class="w-full h-[80vh] bg-white border rounded shadow-sm"
-                title="PDF ビューア"></iframe>
-        <!-- 非 PDF (画像 / Office 等): 「開く」ボタンを大きく表示 -->
-        <div v-else class="text-center py-20">
+        <!-- モバイル (Android Chrome は iframe で PDF を render せず DL する): 大きい「開く」ボタンのみ -->
+        <div class="md:hidden text-center py-12">
           <a :href="fileUrl" target="_blank" rel="noopener"
-             class="inline-block bg-blue-600 text-white text-lg font-medium px-8 py-4 rounded-lg hover:bg-blue-700">
-            📥 ファイルを開く
+             class="inline-block bg-blue-600 text-white text-xl font-bold px-10 py-5 rounded-2xl hover:bg-blue-700 shadow-lg active:scale-95 transition">
+            📄 {{ isPdf ? 'PDF を開く' : 'ファイルを開く' }}
           </a>
+          <p class="mt-4 text-sm text-gray-500">タップすると別タブで開きます</p>
         </div>
-
-        <!-- モバイル / iframe 未対応端末向け fallback ボタン -->
-        <div v-if="isPdf" class="mt-4 text-center sm:hidden">
-          <a :href="fileUrl" target="_blank" rel="noopener"
-             class="inline-block bg-blue-600 text-white text-base font-medium px-6 py-3 rounded-lg hover:bg-blue-700">
-            📄 PDF を別タブで開く
-          </a>
-          <p class="mt-2 text-xs text-gray-500">表示されない場合はこちらをタップ</p>
+        <!-- デスクトップ (md+): iframe で inline 表示 -->
+        <div class="hidden md:block">
+          <iframe v-if="isPdf" :src="fileUrl" class="w-full h-[80vh] bg-white border rounded shadow-sm"
+                  title="PDF ビューア"></iframe>
+          <div v-else class="text-center py-20">
+            <a :href="fileUrl" target="_blank" rel="noopener"
+               class="inline-block bg-blue-600 text-white text-lg font-medium px-8 py-4 rounded-lg hover:bg-blue-700">
+              📥 ファイルを開く
+            </a>
+          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
Android Chrome は iframe 内で PDF を render せず DL ダイアログを出す。 #43 で iframe を埋めたが、これが原因で受信者 (高齢 Android ユーザー) で「画面は出るがダウンロードされる」現象が発生。

修正:
- モバイル (max-md): iframe 廃止 → 大きい「📄 PDF を開く」ボタンのみ。タップで新タブ → Chrome 組込み PDF ビューアで inline 表示
- デスクトップ (md+): 従来どおり iframe で inline 表示

## 検証
- [x] CDP (Windows Chrome) で desktop 表示 → iframe で inline 表示確認 (PR #43 で確認済み)
- [x] R2 presign URL 直接 curl: `Content-Type: application/pdf` + `Content-Disposition: inline` 返却確認
- [ ] CI: typecheck + vitest
- [ ] staging deploy 後、Android Chrome で実機確認