### PR TITLE
feat(viewer): render PDFs with PDF.js canvas

### DIFF
--- a/app/pages/v/[token].vue
+++ b/app/pages/v/[token].vue
@@ -2,10 +2,10 @@
 // 配信受信者向けの公開 viewer ページ。ログイン不要。
 // /api/notify/read/{token} 経由で 302 redirect されてくる。
 //
-// ページ内で
-//   GET /api/notify/v/{token}      → メタデータ JSON
-//   <iframe src="...v/{token}/file"> → R2 inline PDF
-// を呼ぶ。
+// PDF は vue-pdf-embed (PDF.js) で <canvas> に描画する。
+// LINE / LINE WORKS の内蔵 webview は PDF をネイティブ表示できないので、
+// canvas に描画するしか確実な inline 表示の方法がない。
+import VuePdfEmbed from 'vue-pdf-embed'
 
 const route = useRoute()
 const config = useRuntimeConfig()
@@ -25,10 +25,17 @@ interface ViewMetadata {
 
 const meta = ref<ViewMetadata | null>(null)
 const status = ref<'loading' | 'ok' | 'gone' | 'not_found' | 'error'>('loading')
+const pdfLoaded = ref(false)
+const pdfPages = ref(0)
+const pdfError = ref('')
 
 const isPdf = computed(() => {
   const name = meta.value?.file_name ?? ''
   return name.toLowerCase().endsWith('.pdf')
+})
+const isImage = computed(() => {
+  const name = meta.value?.file_name?.toLowerCase() ?? ''
+  return /\.(png|jpe?g|gif|webp|svg)$/.test(name)
 })
 
 function formatSize(bytes: number | null): string {
@@ -59,11 +66,20 @@ async function load() {
   }
 }
 
+function onPdfLoaded(doc: { numPages: number }) {
+  pdfPages.value = doc?.numPages ?? 0
+  pdfLoaded.value = true
+}
+
+function onPdfError(e: unknown) {
+  pdfError.value = e instanceof Error ? e.message : String(e)
+}
+
 onMounted(load)
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-50">
+  <div class="min-h-screen bg-gray-100">
     <!-- 上部バー -->
     <header class="bg-white shadow-sm border-b sticky top-0 z-10">
       <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
@@ -76,16 +92,13 @@ onMounted(load)
             <span v-if="meta.source_sender"> · {{ meta.source_sender }}</span>
             <span v-if="meta.source_received_at"> · {{ formatDate(meta.source_received_at) }}</span>
             <span v-if="meta.file_size_bytes"> · {{ formatSize(meta.file_size_bytes) }}</span>
+            <span v-if="isPdf && pdfPages"> · {{ pdfPages }}ページ</span>
           </div>
         </div>
-        <a v-if="status === 'ok'" :href="fileUrl" target="_blank" rel="noopener"
-           class="shrink-0 bg-blue-600 text-white text-sm font-medium px-4 py-2 rounded hover:bg-blue-700 whitespace-nowrap">
-          📄 開く
-        </a>
       </div>
     </header>
 
-    <main class="max-w-5xl mx-auto px-4 py-4">
+    <main class="max-w-5xl mx-auto px-2 sm:px-4 py-3">
       <div v-if="status === 'loading'" class="text-center py-20 text-gray-500">
         読み込み中…
       </div>
@@ -103,27 +116,45 @@ onMounted(load)
           再試行
         </button>
       </div>
-      <div v-else>
-        <!-- モバイル (Android Chrome は iframe で PDF を render せず DL する): 大きい「開く」ボタンのみ -->
-        <div class="md:hidden text-center py-12">
-          <a :href="fileUrl" target="_blank" rel="noopener"
-             class="inline-block bg-blue-600 text-white text-xl font-bold px-10 py-5 rounded-2xl hover:bg-blue-700 shadow-lg active:scale-95 transition">
-            📄 {{ isPdf ? 'PDF を開く' : 'ファイルを開く' }}
-          </a>
-          <p class="mt-4 text-sm text-gray-500">タップすると別タブで開きます</p>
-        </div>
-        <!-- デスクトップ (md+): iframe で inline 表示 -->
-        <div class="hidden md:block">
-          <iframe v-if="isPdf" :src="fileUrl" class="w-full h-[80vh] bg-white border rounded shadow-sm"
-                  title="PDF ビューア"></iframe>
-          <div v-else class="text-center py-20">
-            <a :href="fileUrl" target="_blank" rel="noopener"
-               class="inline-block bg-blue-600 text-white text-lg font-medium px-8 py-4 rounded-lg hover:bg-blue-700">
-              📥 ファイルを開く
-            </a>
+      <div v-else-if="isPdf">
+        <!-- PDF.js (canvas 描画): モバイル webview 含む全環境で確実に inline 表示 -->
+        <ClientOnly>
+          <div v-if="!pdfLoaded && !pdfError" class="text-center py-12 text-gray-500 text-sm">
+            PDF を読み込み中…
           </div>
-        </div>
+          <div v-if="pdfError" class="text-center py-12">
+            <p class="text-red-700 text-sm">PDF の読み込みに失敗しました</p>
+            <p class="text-xs text-gray-500 mt-1">{{ pdfError }}</p>
+          </div>
+          <VuePdfEmbed
+            :source="fileUrl"
+            class="bg-white shadow-sm rounded"
+            @loaded="onPdfLoaded"
+            @loading-failed="onPdfError"
+          />
+        </ClientOnly>
+      </div>
+      <div v-else-if="isImage" class="text-center">
+        <img :src="fileUrl" :alt="meta?.file_name ?? ''" class="max-w-full mx-auto rounded shadow-sm" />
+      </div>
+      <div v-else class="text-center py-20">
+        <a :href="fileUrl" target="_blank" rel="noopener"
+           class="inline-block bg-blue-600 text-white text-lg font-medium px-8 py-4 rounded-lg hover:bg-blue-700">
+          📥 ファイルを開く
+        </a>
       </div>
     </main>
   </div>
 </template>
+
+<style scoped>
+/* vue-pdf-embed のページを横に余白を持たせて並べる (見やすさ) */
+:deep(.vue-pdf-embed__page) {
+  margin-bottom: 12px;
+}
+:deep(.vue-pdf-embed__page canvas) {
+  width: 100% !important;
+  height: auto !important;
+  display: block;
+}
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@nuxtjs/tailwindcss": "^6.14.0",
         "nuxt": "^4.4.2",
         "vue": "^3.5.31",
+        "vue-pdf-embed": "^2.1.4",
         "vue-router": "^5.0.4"
       },
       "devDependencies": {
@@ -1230,6 +1231,256 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -8716,6 +8967,18 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
+    },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
@@ -11967,6 +12230,18 @@
       "resolved": "https://registry.npmjs.org/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz",
       "integrity": "sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==",
       "license": "MIT"
+    },
+    "node_modules/vue-pdf-embed": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vue-pdf-embed/-/vue-pdf-embed-2.1.4.tgz",
+      "integrity": "sha512-rZuRpQ4kJXKXCdZBCg3WZcYfrhDMJElcJQsS1V8KlJICDtFzzAzeDDSJwQU89Dx447Dv018P3zj/4UiAjBwvyg==",
+      "license": "MIT",
+      "dependencies": {
+        "pdfjs-dist": "^4.10.38"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.0"
+      }
     },
     "node_modules/vue-router": {
       "version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.4.2",
     "vue": "^3.5.31",
+    "vue-pdf-embed": "^2.1.4",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
PDF を vue-pdf-embed (PDF.js wrapper) で <canvas> に描画する。LINE / LINE WORKS の内蔵 webview は PDF をネイティブ表示できないため、canvas 描画が唯一の確実な inline 表示方法。

## 構成
- PDF (`.pdf`): VuePdfEmbed コンポーネントで全ページ縦並び表示
- 画像 (`.png/.jpg/...`): `<img>` で inline
- その他: 「ファイルを開く」ボタン (新タブで API ストリーム)

backend rust-alc-api PR #303 で `/api/notify/v/{token}/file` が API ストリーム (Content-Type/Disposition: inline) に変わるので CORS 問題なし。

## Test plan
- [x] vitest pass
- [ ] CI: typecheck + vitest
- [ ] backend #303 + this を staging に揃えて反映後、Android 実機 (LINE/LINE WORKS webview) で canvas 描画されることを確認

🚨 backend PR #303 が staging に反映される前にマージすると、frontend が古い backend (R2 redirect) を叩いて CORS で失敗する。staging では rust-alc-api → nuxt-notify の順で deploy されるよう PR をマージしてください。