### PR TITLE
chore: update @ippoan/auth-client to ^0.2.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "nuxt-notify",
       "hasInstallScript": true,
       "dependencies": {
-        "@ippoan/auth-client": "^0.2.10",
+        "@ippoan/auth-client": "^0.2.28",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "nuxt": "^4.4.2",
         "vue": "^3.5.31",
@@ -1033,9 +1033,9 @@
       "license": "MIT"
     },
     "node_modules/@ippoan/auth-client": {
-      "version": "0.2.10",
-      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.2.10/84881621c09b304cd5d3dcc548a7aef698a9f7ec",
-      "integrity": "sha512-VHBgGtZjCRFDim74WpDn1nh/H/WCrD9BaIQJhiTeQjVsWJxwRJYYnR46rpYCcMNtYgiBttF2PlSJNRWOnmo+vQ==",
+      "version": "0.2.28",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.2.28/8884caa8e55c071d7f2fa0e2a3bc999cd88b1551",
+      "integrity": "sha512-PSdj6ZVe3/nDTZksrXtvHVxO1eQWx4rGclg4vIzhlZevYOwZztkvE82Bf1EBuhZUeLWJxm9CmFyMilYpOcimYQ==",
       "dependencies": {
         "uqr": "^0.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "^0.2.10",
+    "@ippoan/auth-client": "^0.2.28",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.4.2",
     "vue": "^3.5.31",


### PR DESCRIPTION
## Summary

- `@ippoan/auth-client` を `^0.2.10` → `^0.2.28` に bump
- auth-worker PR #86 (merged) で `/admin/sso` 戻るボタンが `?from=` 対応 → auth-client 0.2.28 が caller origin を付与
- 結果: AuthToolbar (app.vue) から設定を開いた時、戻るボタンが nuxt-notify に戻る

## Backward compat

`?from=` がない旧 client から開いた場合は `/top` フォールバック (auth-worker 側で対応済み)。

## Test plan
- [x] `npm install` で lockfile 更新 (3箇所の 0.2.28 反映)
- [ ] CI pass
- [ ] staging deploy 後、AuthToolbar から設定 → 戻る = nuxt-notify