### PR TITLE
fix: switch authWorkerUrl default from mtamaramu to ippoan domain

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       apiBase: 'http://localhost:8080',
-      authWorkerUrl: 'https://auth.mtamaramu.com',
+      authWorkerUrl: 'https://auth.ippoan.org',
       stagingTenantId: '',
     },
   },


### PR DESCRIPTION
## Summary

`runtimeConfig.public.authWorkerUrl` のデフォルト値が旧ドメイン (`auth.mtamaramu.com`) のままだった。本番 / staging は wrangler.toml の `NUXT_PUBLIC_AUTH_WORKER_URL` で `auth.ippoan.org` / `auth-staging.ippoan.org` に上書きされるので動いていたが、ローカル dev で env 未設定の時に旧 worker に飛んでしまう。

ci-workflows main の `check-old-auth-domain` ジョブも blocked するので、新ドメインを default に揃える。

## Test plan
- [x] `nuxt.config.ts` のみ変更 (1行)
- [ ] CI pass
- [ ] 既存 staging / 本番デプロイの環境変数は変更不要 (上書き済み)