### PR TITLE
feat(documents): redaction UI (status badge, PDF preview, bulk/per-row redact)

### DIFF
--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAuth } from '@ippoan/auth-client'
+import VuePdfEmbed from 'vue-pdf-embed'
 
 const route = useRoute()
 const { apiFetch } = useApi()
@@ -16,6 +17,12 @@ interface NotifyDocument {
   extracted_summary: string | null
   extraction_status: string
   distribution_status: string
+  // redact パイプライン (migration 109、PR rust-alc-api#314)
+  redaction_status: string
+  redacted_r2_key: string | null
+  redacted_at: string | null
+  redactions_applied: number | null
+  redaction_error: string | null
   created_at: string
 }
 
@@ -44,6 +51,47 @@ const loading = ref(true)
 const error = ref('')
 const showDistribute = ref(false)
 
+// プレビュー: redacted (default) / 原本 を切替
+const previewMode = ref<'redacted' | 'original'>('redacted')
+const previewPdfData = ref<Uint8Array | null>(null)
+const previewLoading = ref(false)
+const previewError = ref('')
+const pdfPages = ref(0)
+
+// 再 redact 実行中フラグ + ポーリング制御
+const recomputing = ref(false)
+let pollTimer: ReturnType<typeof setTimeout> | null = null
+
+const isPdf = computed(() => {
+  const name = document.value?.file_name?.toLowerCase() ?? ''
+  return name.endsWith('.pdf')
+})
+
+// 配信は redact 完了 / skipped (PDF以外) のみ許可。
+// backend (distribute.rs) でも 400 ブロックされるが、UI 側でもボタンを disable する。
+// undefined (旧 API) は PDF なら disable、それ以外なら許可 (旧挙動維持)。
+const canDistribute = computed(() => {
+  const s = document.value?.redaction_status
+  if (s === 'completed' || s === 'skipped') return true
+  if (!s) return !isPdf.value // status 不明 + PDF は disable で安全側
+  return false
+})
+
+const distributeDisabledReason = computed(() => {
+  if (!document.value) return ''
+  switch (document.value.redaction_status) {
+    case 'pending':
+      return 'マスク処理待ち。完了後に配信できます'
+    case 'processing':
+      return 'マスク処理中。完了をお待ちください'
+    case 'failed':
+      return 'マスク失敗。「再 redact」をお試しください'
+    default:
+      // undefined (旧 API) のとき、PDF だけブロック
+      return isPdf.value ? '「🔄 redact 開始」でマスク処理を開始してください' : ''
+  }
+})
+
 async function load() {
   loading.value = true
   error.value = ''
@@ -51,11 +99,98 @@ async function load() {
     const res = await apiFetch<DocumentResponse>(`/notify/documents/${documentId.value}`)
     document.value = res.document
     deliveries.value = res.deliveries
+    // processing 中は 5 秒後に再取得 (UI が「処理中」のまま固まらないように)
+    schedulePollIfProcessing()
   } catch (e: any) {
     error.value = e.message || String(e)
   } finally {
     loading.value = false
   }
+}
+
+function schedulePollIfProcessing() {
+  if (pollTimer) {
+    clearTimeout(pollTimer)
+    pollTimer = null
+  }
+  const s = document.value?.redaction_status
+  if (s === 'processing' || s === 'pending') {
+    pollTimer = setTimeout(() => {
+      // silent reload (loading フラグは触らない、UI ちらつき防止)
+      apiFetch<DocumentResponse>(`/notify/documents/${documentId.value}`)
+        .then((res) => {
+          document.value = res.document
+          deliveries.value = res.deliveries
+          schedulePollIfProcessing()
+          // 状態が変わってプレビュー対象が変わるなら再ロード
+          if (document.value?.redaction_status === 'completed' && isPdf.value) {
+            loadPreview()
+          }
+        })
+        .catch(() => {
+          // 失敗してもポーリングは諦める (ユーザーが手動 reload を期待)
+        })
+    }, 5000)
+  }
+}
+
+async function loadPreview() {
+  if (!document.value || !isPdf.value) return
+  previewLoading.value = true
+  previewError.value = ''
+  pdfPages.value = 0
+  try {
+    const config = useRuntimeConfig()
+    const apiBase = config.public.apiBase as string
+    const headers: Record<string, string> = {}
+    if (token.value) {
+      headers.Authorization = `Bearer ${token.value}`
+    } else if (orgId.value) {
+      headers['X-Tenant-ID'] = orgId.value
+    }
+    const qs = previewMode.value === 'original' ? '?original=true' : ''
+    // VuePdfEmbed は string URL で fetch すると認証ヘッダを付けられない。
+    // 認証付きで bytes を取得して Uint8Array で渡す (PDF.js が直接受け取れる形)。
+    const res = await fetch(`${apiBase}/api/notify/documents/${document.value.id}/preview${qs}`, { headers })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const buf = await res.arrayBuffer()
+    previewPdfData.value = new Uint8Array(buf)
+  } catch (e: any) {
+    previewError.value = e.message || String(e)
+    previewPdfData.value = null
+  } finally {
+    previewLoading.value = false
+  }
+}
+
+function onPdfLoaded(doc: { numPages: number }) {
+  pdfPages.value = doc?.numPages ?? 0
+}
+
+function onPdfError(e: unknown) {
+  previewError.value = e instanceof Error ? e.message : String(e)
+}
+
+async function recomputeRedaction() {
+  if (!document.value || recomputing.value) return
+  if (!confirm('redact を再計算します。プレビューが更新されます。よろしいですか?')) return
+  recomputing.value = true
+  try {
+    await apiFetch(`/notify/documents/${document.value.id}/redact-recompute`, { method: 'POST' })
+    // 状態を即座に処理中に倒して polling 開始 (バック側は async で processing→completed)
+    if (document.value) document.value.redaction_status = 'processing'
+    previewPdfData.value = null
+    schedulePollIfProcessing()
+  } catch (e: any) {
+    alert(`再 redact 失敗: ${e.message ?? e}`)
+  } finally {
+    recomputing.value = false
+  }
+}
+
+function switchPreview(mode: 'redacted' | 'original') {
+  previewMode.value = mode
+  loadPreview()
 }
 
 async function downloadDoc() {
@@ -121,7 +256,53 @@ function deliveryStatusLabel(status: string): { label: string; cls: string } {
   }
 }
 
-onMounted(load)
+function redactionBadge(): { label: string; cls: string } | null {
+  if (!document.value) return null
+  switch (document.value.redaction_status) {
+    case 'completed':
+      return {
+        label: document.value.redactions_applied != null
+          ? `🔒 マスク済 (${document.value.redactions_applied}箇所)`
+          : '🔒 マスク済',
+        cls: 'bg-emerald-100 text-emerald-700',
+      }
+    case 'processing':
+      return { label: '🔄 マスク処理中…', cls: 'bg-blue-100 text-blue-700' }
+    case 'failed':
+      return { label: '⚠️ マスク失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' }
+    case 'skipped':
+      return { label: 'マスク不要 (PDF以外)', cls: 'bg-gray-100 text-gray-600' }
+    default:
+      // undefined: PR #314 未デプロイの API レスポンス互換。
+      // PDF なら「マスク待ち」、それ以外は非表示。
+      return isPdf.value
+        ? { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' }
+        : null
+  }
+}
+
+onMounted(async () => {
+  await load()
+  // PDF なら基本的にプレビューを取得 (preview API 側で COALESCE 動作)。
+  // pending / processing / undefined は「準備中」プレースホルダ表示のまま。
+  // (undefined = PR #314 未デプロイの API。/preview エンドポイント自体が
+  //  存在しないので fetch して 404 にせず、プレースホルダで案内する。)
+  if (isPdf.value && document.value) {
+    const s = document.value.redaction_status
+    if (s === 'completed' || s === 'skipped') {
+      loadPreview()
+    }
+  }
+})
+
+onUnmounted(() => {
+  if (pollTimer) {
+    clearTimeout(pollTimer)
+    pollTimer = null
+  }
+})
 </script>
 
 <template>
@@ -144,11 +325,18 @@ onMounted(load)
     <div v-else-if="document">
       <!-- ヘッダ -->
       <div class="bg-white border rounded p-4 mb-4">
-        <div class="flex items-start justify-between">
+        <div class="flex items-start justify-between gap-3">
           <div class="flex-1 min-w-0">
-            <h2 class="text-lg font-bold truncate">📄 {{ document.file_name ?? '(無名)' }}</h2>
+            <div class="flex items-center gap-2 flex-wrap">
+              <h2 class="text-lg font-bold truncate">📄 {{ document.file_name ?? '(無名)' }}</h2>
+              <span v-if="redactionBadge()"
+                    :class="['px-2 py-0.5 text-xs rounded-full flex-shrink-0', redactionBadge()!.cls]">
+                {{ redactionBadge()!.label }}
+              </span>
+            </div>
             <div class="text-xs text-gray-500 mt-1">
               {{ formatSize(document.file_size_bytes) }} · 受信 {{ formatDate(document.created_at) }}
+              <span v-if="document.redacted_at"> · マスク {{ formatDate(document.redacted_at) }}</span>
             </div>
           </div>
           <div class="flex gap-2 flex-shrink-0">
@@ -157,9 +345,26 @@ onMounted(load)
               ダウンロード
             </button>
             <button @click="showDistribute = true"
-                    class="text-sm bg-blue-600 text-white hover:bg-blue-700 px-3 py-1.5 rounded">
+                    :disabled="!canDistribute"
+                    :title="distributeDisabledReason"
+                    class="text-sm bg-blue-600 text-white hover:bg-blue-700 px-3 py-1.5 rounded disabled:opacity-40 disabled:cursor-not-allowed">
               配信
             </button>
+          </div>
+        </div>
+
+        <!-- 配信ブロック理由 (status≠completed/skipped) -->
+        <div v-if="!canDistribute && distributeDisabledReason"
+             class="mt-3 text-xs bg-yellow-50 border border-yellow-200 text-yellow-800 px-3 py-2 rounded">
+          ℹ️ {{ distributeDisabledReason }}
+        </div>
+
+        <!-- redact 失敗時のエラー詳細 + 再 redact ボタン -->
+        <div v-if="document.redaction_status === 'failed'"
+             class="mt-3 text-xs bg-red-50 border border-red-200 text-red-800 px-3 py-2 rounded">
+          <div class="font-medium mb-1">マスク処理に失敗しました</div>
+          <div v-if="document.redaction_error" class="font-mono break-all">
+            {{ document.redaction_error }}
           </div>
         </div>
 
@@ -171,6 +376,87 @@ onMounted(load)
           <div v-if="document.extracted_summary" class="mt-1 text-gray-600 whitespace-pre-wrap">
             {{ document.extracted_summary }}
           </div>
+        </div>
+      </div>
+
+      <!-- プレビュー (PDF のみ) -->
+      <div v-if="isPdf" class="bg-white border rounded p-4 mb-4">
+        <div class="flex items-center justify-between mb-3 gap-2 flex-wrap">
+          <h3 class="text-sm font-bold">プレビュー</h3>
+          <div class="flex items-center gap-2">
+            <!-- redacted/原本 切替 (redacted がある時のみ) -->
+            <div v-if="document.redacted_r2_key" class="inline-flex rounded border overflow-hidden text-xs">
+              <button @click="switchPreview('redacted')"
+                      :class="previewMode === 'redacted'
+                        ? 'bg-emerald-600 text-white'
+                        : 'bg-white text-gray-700 hover:bg-gray-50'"
+                      class="px-3 py-1">
+                マスク済
+              </button>
+              <button @click="switchPreview('original')"
+                      :class="previewMode === 'original'
+                        ? 'bg-gray-700 text-white'
+                        : 'bg-white text-gray-700 hover:bg-gray-50'"
+                      class="px-3 py-1 border-l">
+                原本
+              </button>
+            </div>
+            <button v-if="document.redaction_status === 'completed' || document.redaction_status === 'failed'"
+                    @click="recomputeRedaction"
+                    :disabled="recomputing"
+                    class="text-xs bg-amber-100 text-amber-800 hover:bg-amber-200 px-3 py-1 rounded disabled:opacity-50">
+              {{ recomputing ? '実行中…' : '🔄 再 redact' }}
+            </button>
+            <span v-if="pdfPages > 0" class="text-xs text-gray-400">
+              {{ pdfPages }} ページ
+            </span>
+          </div>
+        </div>
+
+        <div v-if="previewLoading" class="text-center py-8 text-sm text-gray-500">
+          PDF を読み込み中…
+        </div>
+        <div v-else-if="previewError"
+             class="bg-red-50 border border-red-200 rounded p-3 text-sm text-red-700">
+          プレビュー失敗: {{ previewError }}
+          <button @click="loadPreview" class="ml-2 underline hover:no-underline">再試行</button>
+        </div>
+        <div v-else-if="document.redaction_status === 'processing'"
+             class="text-center py-12">
+          <div class="inline-flex items-center gap-2 text-blue-700">
+            <svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" class="opacity-25"></circle>
+              <path d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" fill="currentColor" class="opacity-75"></path>
+            </svg>
+            <span class="text-sm font-medium">マスク処理中…</span>
+          </div>
+          <p class="text-xs text-gray-500 mt-2">完了次第、自動でここに表示されます</p>
+        </div>
+        <div v-else-if="document.redaction_status === 'pending' || !document.redaction_status"
+             class="text-center py-12">
+          <div class="text-sm text-gray-700 mb-2">⏳ 準備中</div>
+          <p class="text-xs text-gray-500">
+            このドキュメントはまだマスク処理されていません。
+            <br>
+            「🔄 redact 開始」ボタンで処理を開始できます。
+          </p>
+          <button @click="recomputeRedaction"
+                  :disabled="recomputing"
+                  class="mt-3 text-sm bg-amber-100 text-amber-800 hover:bg-amber-200 px-4 py-2 rounded disabled:opacity-50">
+            {{ recomputing ? '実行中…' : '🔄 redact 開始' }}
+          </button>
+        </div>
+        <ClientOnly v-else-if="previewPdfData">
+          <VuePdfEmbed
+            :source="previewPdfData"
+            class="bg-gray-50 rounded border max-h-[600px] overflow-y-auto"
+            @loaded="onPdfLoaded"
+            @loading-failed="onPdfError"
+          />
+        </ClientOnly>
+        <div v-else class="text-center py-8 text-sm text-gray-500">
+          プレビューを取得できません。
+          <button @click="loadPreview" class="ml-2 underline hover:no-underline">再試行</button>
         </div>
       </div>
 
@@ -216,3 +502,15 @@ onMounted(load)
                      @distributed="onDistributed" />
   </div>
 </template>
+
+<style scoped>
+/* vue-pdf-embed のページレイアウト整形 (v/[token].vue と統一) */
+:deep(.vue-pdf-embed__page) {
+  margin-bottom: 8px;
+}
+:deep(.vue-pdf-embed__page canvas) {
+  width: 100% !important;
+  height: auto !important;
+  display: block;
+}
+</style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -10,12 +10,18 @@ interface NotifyDocument {
   source_subject: string | null
   extraction_status: string
   distribution_status: string
+  redaction_status: string
+  redactions_applied: number | null
   created_at: string
 }
 
 const documents = ref<NotifyDocument[]>([])
 const loading = ref(true)
 const error = ref('')
+const bulkRunning = ref(false)
+const bulkProgress = ref<{ done: number; total: number } | null>(null)
+// 個別行で実行中の document_id 集合 (二重クリック防止 + ボタン表示)
+const recomputingIds = ref<Set<string>>(new Set())
 
 async function reload() {
   loading.value = true
@@ -26,6 +32,84 @@ async function reload() {
     error.value = e.message || String(e)
   } finally {
     loading.value = false
+  }
+}
+
+// 一括 redact の対象: PDF かつ redaction_status が「未処理」相当
+//  - undefined: API が PR #314 未デプロイ (production 互換)
+//  - 'pending': migration 109 default (バックフィルなし)
+//  - 'failed':  Gemini 失敗の retry
+// processing 中は触らない (重複呼び出し防止)、completed は使い回し。
+const pendingPdfDocs = computed(() =>
+  documents.value.filter((d) => {
+    const s = d.redaction_status
+    if (s === 'completed' || s === 'processing' || s === 'skipped') return false
+    return (d.file_name ?? '').toLowerCase().endsWith('.pdf')
+  }),
+)
+
+// API が 404 を返したら「本番未デプロイ」とみなしてフラグを立てる。
+// 一度立ったら再度ボタンを叩かないよう全 redact UI を抑制する。
+const apiNotDeployed = ref(false)
+
+function isNotDeployedError(e: any): boolean {
+  const msg = String(e?.message ?? e)
+  // ofetch / $fetch は HTTP エラーを `[POST] "..." 404` で返す
+  return msg.includes('404') || e?.statusCode === 404 || e?.status === 404
+}
+
+async function recomputeOne(doc: NotifyDocument) {
+  if (recomputingIds.value.has(doc.id)) return
+  recomputingIds.value = new Set([...recomputingIds.value, doc.id])
+  try {
+    await apiFetch(`/notify/documents/${doc.id}/redact-recompute`, { method: 'POST' })
+    // 即座に状態を processing に倒して UI 反映 (バック側は async)
+    doc.redaction_status = 'processing'
+  } catch (e: any) {
+    if (isNotDeployedError(e)) {
+      apiNotDeployed.value = true
+    } else {
+      alert(`redact 失敗 (${doc.file_name}): ${e.message ?? e}`)
+    }
+  } finally {
+    const next = new Set(recomputingIds.value)
+    next.delete(doc.id)
+    recomputingIds.value = next
+  }
+}
+
+async function bulkRecompute() {
+  const targets = pendingPdfDocs.value
+  if (targets.length === 0) return
+  if (!confirm(`未処理 / 失敗の PDF ${targets.length} 件を一括で redact します。よろしいですか?`)) return
+  bulkRunning.value = true
+  bulkProgress.value = { done: 0, total: targets.length }
+  try {
+    // バックは tokio::spawn で並列処理するので、同時に POST しても
+    // 直列にする必要はない。ただ rate limit や DB 負荷を抑えるため逐次実行する。
+    for (const doc of targets) {
+      try {
+        await apiFetch(`/notify/documents/${doc.id}/redact-recompute`, { method: 'POST' })
+        doc.redaction_status = 'processing'
+      } catch (e: any) {
+        if (isNotDeployedError(e)) {
+          apiNotDeployed.value = true
+          break // 全件 404 になるはずなのでループ中断
+        }
+        // 個別失敗は止めずに続行 (後で reload で状態を確認)
+        console.error('redact failed', doc.id, e)
+      }
+      bulkProgress.value = { done: bulkProgress.value.done + 1, total: targets.length }
+    }
+  } finally {
+    bulkRunning.value = false
+    if (!apiNotDeployed.value) {
+      // ステータス確認のため直後に最新化 (processing → completed の自動遷移を見るために
+      // ユーザーが個別ページで polling する前提)
+      await reload()
+    }
+    // progress 表示は 3 秒後に消す
+    setTimeout(() => { bulkProgress.value = null }, 3000)
   }
 }
 
@@ -56,16 +140,72 @@ function distributionBadge(status: string): { label: string; cls: string } {
       return { label: '未配信', cls: 'bg-gray-100 text-gray-600' }
   }
 }
+
+// redaction_status: PDF アップロード時に async で金額マスク (migration 109)。
+// completed / skipped 以外は配信時に backend で 400 ブロックされる。
+// 注: PR #314 が production にデプロイされる前は API が redaction_status を
+//     返さない (undefined) → 「マスク待ち」扱いで PDF にだけバッジ表示する。
+function redactionBadge(doc: NotifyDocument): { label: string; cls: string } | null {
+  const isPdf = (doc.file_name ?? '').toLowerCase().endsWith('.pdf')
+  switch (doc.redaction_status) {
+    case 'completed':
+      return {
+        label: doc.redactions_applied != null ? `🔒 ${doc.redactions_applied}箇所` : '🔒 マスク済',
+        cls: 'bg-emerald-100 text-emerald-700',
+      }
+    case 'processing':
+      return { label: '🔄 マスク処理中', cls: 'bg-blue-100 text-blue-700' }
+    case 'failed':
+      return { label: '⚠️ マスク失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return isPdf ? { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' } : null
+    case 'skipped':
+      // PDF 以外は表示しない (ノイズ削減)
+      return null
+    default:
+      // undefined: PR #314 未デプロイの API レスポンス。
+      // PDF だけ「マスク待ち」を出して Phase 3 移行を促す。
+      return isPdf ? { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' } : null
+  }
+}
 </script>
 
 <template>
   <div>
     <div class="flex justify-between items-center mb-4 gap-2 flex-wrap">
       <h2 class="text-xl font-bold">ドキュメント一覧</h2>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-2 flex-wrap">
+        <button v-if="pendingPdfDocs.length > 0 && !apiNotDeployed"
+                @click="bulkRecompute"
+                :disabled="bulkRunning"
+                class="px-3 py-1.5 text-sm bg-amber-100 text-amber-800 hover:bg-amber-200 rounded disabled:opacity-50">
+          🔒 未処理 PDF を一括 redact ({{ pendingPdfDocs.length }})
+        </button>
         <FolderWatcher @uploaded="reload" />
         <UploadButton @uploaded="reload" />
       </div>
+    </div>
+
+    <!-- 一括処理進捗 -->
+    <div v-if="bulkProgress"
+         class="mb-3 bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800">
+      <div v-if="bulkRunning">
+        🔄 redact 開始中… {{ bulkProgress.done }} / {{ bulkProgress.total }}
+      </div>
+      <div v-else>
+        ✅ {{ bulkProgress.total }} 件の redact 開始を送信しました。完了状況は各行を確認してください。
+      </div>
+    </div>
+
+    <!-- 本番 API 未デプロイ通知 (PR #314 タグリリース前) -->
+    <div v-if="apiNotDeployed"
+         class="mb-3 bg-yellow-50 border border-yellow-300 rounded p-3 text-sm text-yellow-900">
+      <div class="font-medium mb-1">⚠️ redact API がまだ本番デプロイされていません</div>
+      <p class="text-xs">
+        rust-alc-api を <code>/tag-release patch</code> でリリースして
+        <code>NOTIFY_REDACT_2STAGE=1</code> を設定すると利用可能になります。
+        現状では PDF の金額マスクは無効です。
+      </p>
     </div>
 
     <!-- FolderWatcher の pending list はここに Teleport される -->
@@ -76,27 +216,46 @@ function distributionBadge(status: string): { label: string; cls: string } {
     <div v-else-if="documents.length === 0" class="text-gray-400">ドキュメントはまだありません</div>
 
     <div v-else class="space-y-3">
-      <NuxtLink v-for="doc in documents" :key="doc.id"
-                :to="`/documents/${doc.id}`"
-                class="block bg-white rounded-lg shadow p-4 border hover:bg-gray-50 transition">
-        <div class="flex justify-between items-start gap-3">
-          <div class="min-w-0 flex-1">
-            <h3 class="font-semibold truncate">{{ doc.extracted_title || doc.file_name || 'Untitled' }}</h3>
-            <p class="text-sm text-gray-500 mt-1 truncate">{{ doc.extracted_summary || doc.source_subject }}</p>
-            <p class="text-xs text-gray-400 mt-1">
-              {{ doc.source_sender }} · {{ new Date(doc.created_at).toLocaleString('ja-JP') }}
-            </p>
+      <div v-for="doc in documents" :key="doc.id"
+           class="bg-white rounded-lg shadow border hover:bg-gray-50 transition">
+        <NuxtLink :to="`/documents/${doc.id}`" class="block p-4">
+          <div class="flex justify-between items-start gap-3">
+            <div class="min-w-0 flex-1">
+              <h3 class="font-semibold truncate">{{ doc.extracted_title || doc.file_name || 'Untitled' }}</h3>
+              <p class="text-sm text-gray-500 mt-1 truncate">{{ doc.extracted_summary || doc.source_subject }}</p>
+              <p class="text-xs text-gray-400 mt-1">
+                {{ doc.source_sender }} · {{ new Date(doc.created_at).toLocaleString('ja-JP') }}
+              </p>
+            </div>
+            <div class="flex gap-2 flex-shrink-0 flex-wrap justify-end">
+              <span v-if="redactionBadge(doc)"
+                    :class="['px-2 py-0.5 text-xs rounded-full', redactionBadge(doc)!.cls]">
+                {{ redactionBadge(doc)!.label }}
+              </span>
+              <span :class="['px-2 py-0.5 text-xs rounded-full', extractionBadge(doc.extraction_status).cls]">
+                {{ extractionBadge(doc.extraction_status).label }}
+              </span>
+              <span :class="['px-2 py-0.5 text-xs rounded-full', distributionBadge(doc.distribution_status).cls]">
+                {{ distributionBadge(doc.distribution_status).label }}
+              </span>
+            </div>
           </div>
-          <div class="flex gap-2 flex-shrink-0">
-            <span :class="['px-2 py-0.5 text-xs rounded-full', extractionBadge(doc.extraction_status).cls]">
-              {{ extractionBadge(doc.extraction_status).label }}
-            </span>
-            <span :class="['px-2 py-0.5 text-xs rounded-full', distributionBadge(doc.distribution_status).cls]">
-              {{ distributionBadge(doc.distribution_status).label }}
-            </span>
-          </div>
+        </NuxtLink>
+
+        <!-- 未処理 PDF は個別 redact 開始ボタンを表示。
+             (undefined / pending / failed の PDF が対象) -->
+        <div v-if="['pending', 'failed', undefined].includes(doc.redaction_status as any)
+                   && (doc.file_name ?? '').toLowerCase().endsWith('.pdf')"
+             class="px-4 pb-3 -mt-1">
+          <button @click="recomputeOne(doc)"
+                  :disabled="recomputingIds.has(doc.id)"
+                  class="text-xs bg-amber-50 text-amber-800 hover:bg-amber-100 border border-amber-200 px-3 py-1 rounded disabled:opacity-50">
+            {{ recomputingIds.has(doc.id) ? '実行中…'
+               : doc.redaction_status === 'failed' ? '🔄 redact を再試行'
+               : '🔄 redact 開始' }}
+          </button>
         </div>
-      </NuxtLink>
+      </div>
     </div>
   </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,4 +16,16 @@ export default defineNuxtConfig({
       stagingTenantId: '',
     },
   },
+
+  vite: {
+    server: {
+      // wt-quick (cloudflared trycloudflare.com) 経由のアクセスを許可
+      allowedHosts: ['.trycloudflare.com'],
+    },
+    optimizeDeps: {
+      // @ippoan/auth-client を Vite pre-bundle すると useRuntimeConfig 等の
+      // 重複 import で不正 JS になる。除外して通常 ESM 解決に任せる。
+      exclude: ['@ippoan/auth-client'],
+    },
+  },
 })


### PR DESCRIPTION
## What

rust-alc-api PR #314 (async redact pipeline) に対応する nuxt-notify 側の admin UI。upload/ingest 時に async で実行される redact の状態を可視化し、配信前のプレビュー確認を可能にする。

## 主要 UI

### 一覧ページ
- redaction_status バッジ (🔒 N箇所 / 🔄 マスク処理中 / ⚠️ 失敗 / マスク待ち)
- 「🔒 未処理 PDF を一括 redact」ボタン (件数表示付き) + 各行 individual ボタン
- API 404 を検出したら「本番未デプロイ」バナー (PR #314 のリリース前後で UI が滑らかに繋がる)

### 詳細ページ
- redaction_status バッジ + error 表示 (failed 時)
- vue-pdf-embed で PDF プレビュー (Bearer 認証付き fetch → Uint8Array)
  - completed: redacted 表示 / 「マスク済 / 原本」トグル
  - processing: スピナー + 「完了次第ここに表示されます」
  - pending or undefined: 「⏳ 準備中」+ 「🔄 redact 開始」ボタン
  - failed: エラー + 再試行
- 「🔄 再 redact」 (completed/failed) → POST /redact-recompute → 5 秒間隔 polling で status 反映
- 配信ボタン disabled (redaction_status≠completed/skipped)、理由をホバー表示

## 設定

\`nuxt.config.ts\` に Vite 設定追加:
- \`server.allowedHosts: ['.trycloudflare.com']\` (wt-quick 互換)
- \`optimizeDeps.exclude: ['@ippoan/auth-client']\` (pre-bundle 不正 JS 回避)

## 後続作業

- **Phase 2.5 (別 PR)**: WebSocket hibernation Durable Object で polling 置換
- **Phase 3 (rust-alc-api)**: \`/tag-release patch\` + 本番 \`NOTIFY_REDACT_2STAGE=1\` 設定
- **staging R2 設定確認**: 検証中に \`r2 upload: Connection reset by peer\` 発生 → notify_storage の bucket 設定を staging で要確認 (本 PR とは別件)

## 設計詳細

\`/home/yhonda/.claude/plans/pr-313-peaceful-ocean.md\` 参照