### PR TITLE
fix(preview): abort + clone ArrayBuffer to prevent PDF.js Worker detach

### DIFF
--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useAuth } from '@ippoan/auth-client'
 import VuePdfEmbed from 'vue-pdf-embed'
+import { fetchPdfBytes } from '~/utils/preview-fetch'
 
 const route = useRoute()
 const { apiFetch } = useApi()
@@ -62,6 +63,14 @@ const pdfPages = ref(0)
 // 再 redact 実行中フラグ + ポーリング制御
 const recomputing = ref(false)
 let pollTimer: ReturnType<typeof setTimeout> | null = null
+
+// 進行中の preview fetch を中断するための controller。
+// tab 切替 (switchPreview) / WS event (onRedactUpdate) / 再 redact 完了 polling が
+// 並行に loadPreview() を呼ぶと、PDF.js Worker がまだ前の Uint8Array を処理中に
+// 新しい代入が走り、Worker への postMessage 時に「ArrayBuffer at index 0 is
+// already detached」が発生する。常に直前の fetch を abort + buffer を独立 copy
+// (buf.slice(0)) することで、Worker 委譲済 buffer と main thread の ref を切り離す。
+let previewAbort: AbortController | null = null
 
 const isPdf = computed(() => {
   const name = document.value?.file_name?.toLowerCase() ?? ''
@@ -137,6 +146,13 @@ function schedulePollIfProcessing() {
 
 async function loadPreview() {
   if (!document.value || !isPdf.value) return
+  // 直前の fetch があれば abort。古い ArrayBuffer が Worker に渡る前の段階で
+  // 切り捨てる (Worker 委譲後はこちらでキャンセルできないため、network 段で止める)。
+  previewAbort?.abort()
+  const ctrl = new AbortController()
+  previewAbort = ctrl
+  // 旧 buffer の参照を即座に外す。VuePdfEmbed が前 buffer を破棄できる猶予を作る。
+  previewPdfData.value = null
   previewLoading.value = true
   previewError.value = ''
   pdfPages.value = 0
@@ -152,15 +168,23 @@ async function loadPreview() {
     const qs = previewMode.value === 'original' ? '?original=true' : ''
     // VuePdfEmbed は string URL で fetch すると認証ヘッダを付けられない。
     // 認証付きで bytes を取得して Uint8Array で渡す (PDF.js が直接受け取れる形)。
-    const res = await fetch(`${apiBase}/api/notify/documents/${document.value.id}/preview${qs}`, { headers })
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const buf = await res.arrayBuffer()
-    previewPdfData.value = new Uint8Array(buf)
+    // fetchPdfBytes は内部で buf.slice(0) して独立 ArrayBuffer を返すため、
+    // PDF.js Worker への transfer が main thread 側 ref を detach しない。
+    const bytes = await fetchPdfBytes(
+      `${apiBase}/api/notify/documents/${document.value.id}/preview${qs}`,
+      { headers, signal: ctrl.signal },
+    )
+    if (ctrl.signal.aborted) return
+    previewPdfData.value = bytes
   } catch (e: any) {
+    if (e?.name === 'AbortError' || ctrl.signal.aborted) return
     previewError.value = e.message || String(e)
     previewPdfData.value = null
   } finally {
-    previewLoading.value = false
+    if (previewAbort === ctrl) {
+      previewLoading.value = false
+      previewAbort = null
+    }
   }
 }
 
@@ -321,6 +345,9 @@ onUnmounted(() => {
     clearTimeout(pollTimer)
     pollTimer = null
   }
+  // 進行中の preview fetch があれば abort。leak した Worker 通信を絶つ。
+  previewAbort?.abort()
+  previewAbort = null
 })
 </script>
 

--- a/app/utils/preview-fetch.ts
+++ b/app/utils/preview-fetch.ts
@@ -1,0 +1,29 @@
+/**
+ * Fetch a PDF as `Uint8Array` with abort + ArrayBuffer cloning.
+ *
+ * 用途: VuePdfEmbed / pdfjs-dist に bytes を渡すための共通取得経路。
+ * 認証付きで取りたいので URL 直渡しは使えず、`fetch` → `arrayBuffer()` → `Uint8Array`
+ * の流れを切り出している。
+ *
+ * 重要: 返す `Uint8Array` の backing `ArrayBuffer` は **元の response から切り離した
+ * 独立コピー** (`buf.slice(0)`)。pdfjs-dist worker は内部で `postMessage(transfer)`
+ * を行い、渡した buffer を detach する。tab 切替 / WS イベント / 再 redact 完了
+ * polling が並行して `loadPreview()` を呼ぶと、PDF.js Worker がまだ前 buffer を
+ * 処理している間に新しい代入が走り、`Failed to execute 'postMessage' on 'Worker':
+ * ArrayBuffer at index 0 is already detached` が発生する。clone することで
+ * Worker に渡す buffer は新規 instance になり、main thread 側の他参照とは切り離される。
+ *
+ * `signal` を渡せば `AbortController.abort()` で network 段階で fetch を中断でき、
+ * 古い ArrayBuffer が Worker に届く前に止められる。
+ */
+export async function fetchPdfBytes(
+  url: string,
+  init: { headers?: Record<string, string>; signal?: AbortSignal } = {},
+): Promise<Uint8Array> {
+  const res = await fetch(url, init)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const buf = await res.arrayBuffer()
+  // `.slice(0)` で独立 ArrayBuffer をコピー。元 buf が Worker に transfer されて
+  // detach されても、戻り値の Uint8Array.buffer は別 instance なので influence 0。
+  return new Uint8Array(buf.slice(0))
+}

--- a/tests/utils/preview-fetch.test.ts
+++ b/tests/utils/preview-fetch.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { fetchPdfBytes } from '../../app/utils/preview-fetch'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * PDF preview を pdfjs-dist worker に渡す経路の安全性を pin する。
+ *
+ * 主訴: tab 切替や WS event で `loadPreview()` が並行呼びされると、PDF.js Worker が
+ * 前 buffer を `postMessage(transfer)` で受領後に main thread 側で同じ buffer を
+ * 触ると `Failed to execute 'postMessage' on 'Worker': ArrayBuffer at index 0 is
+ * already detached` が発生する。`fetchPdfBytes` は:
+ *   1. `buf.slice(0)` で response の ArrayBuffer から独立 copy を作る (詰め直し)
+ *   2. `signal` を受け取り、`fetch` の network 段で abort できる
+ * の 2 つを満たすことで上記の race を防ぐ。
+ */
+describe('fetchPdfBytes', () => {
+  it('returns Uint8Array whose backing ArrayBuffer is a *clone*, not the original response buffer', async () => {
+    const original = new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer // "%PDF"
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(original),
+    } as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const out = await fetchPdfBytes('https://example.com/doc.pdf')
+    // bytes 内容は同一
+    expect(Array.from(out)).toEqual([0x25, 0x50, 0x44, 0x46])
+    // backing ArrayBuffer は独立 instance であること (clone). これが本テストの
+    // 中心 assertion: Worker への transfer で original を detach されても
+    // out.buffer は別 instance なので影響を受けない。
+    expect(out.buffer).not.toBe(original)
+    expect(out.buffer.byteLength).toBe(original.byteLength)
+  })
+
+  it('forwards signal so an in-flight fetch can be aborted by the caller', async () => {
+    const ctrl = new AbortController()
+    const observed: AbortSignal[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+        if (init?.signal) observed.push(init.signal)
+        // signal の状態を直接 reject に反映する fake fetch
+        return new Promise((_resolve, reject) => {
+          if (init?.signal?.aborted) {
+            reject(new DOMException('aborted', 'AbortError'))
+            return
+          }
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'))
+          })
+        })
+      }),
+    )
+
+    const p = fetchPdfBytes('https://example.com/doc.pdf', { signal: ctrl.signal })
+    ctrl.abort()
+    await expect(p).rejects.toMatchObject({ name: 'AbortError' })
+    expect(observed[0]).toBe(ctrl.signal)
+  })
+
+  it('forwards headers (e.g. Authorization) to the underlying fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    } as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchPdfBytes('https://example.com/doc.pdf', {
+      headers: { Authorization: 'Bearer xyz', 'X-Tenant-ID': 't1' },
+    })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.headers).toEqual({ Authorization: 'Bearer xyz', 'X-Tenant-ID': 't1' })
+  })
+
+  it('throws with status when the response is not ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      } as Response),
+    )
+
+    await expect(fetchPdfBytes('https://example.com/doc.pdf')).rejects.toThrow('HTTP 404')
+  })
+
+  it('uses default empty init object when caller omits options', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    } as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const out = await fetchPdfBytes('https://example.com/doc.pdf')
+    expect(out).toBeInstanceOf(Uint8Array)
+    // 第二引数として `{}` が渡る (signal/headers 無し) こと
+    expect(fetchMock.mock.calls[0][1]).toEqual({})
+  })
+})


### PR DESCRIPTION
PDF preview の document detail で「プレビュー失敗: Failed to execute 'postMessage' on 'Worker': ArrayBuffer at index 0 is already detached」を修正。

## 真因

`app/pages/documents/[id].vue::loadPreview()` で `new Uint8Array(buf)` を
そのまま `previewPdfData` に代入し VuePdfEmbed (pdfjs-dist) に渡していた。
PDF.js Worker は `postMessage(transfer)` で buffer を detach する。

tab 切替 (マスク済 ↔ 原本)・WebSocket event (`onRedactUpdate`)・再 redact 完了
polling が並行して `loadPreview()` を呼ぶと、Worker がまだ前 buffer を処理中に
新しい代入が走り、main thread 側の参照が detach 済みになる。

## 修正

### `app/utils/preview-fetch.ts` (新規)

`fetchPdfBytes(url, { signal, headers })` を切り出し:

- `buf.slice(0)` で独立 ArrayBuffer copy を返す → Worker に transfer されても
  元 buf に依存する main thread 参照は影響なし
- `signal` を fetch に転送 → caller が `AbortController.abort()` で network 段で
  中断できる (古い buffer が Worker に届く前に止める)

### `app/pages/documents/[id].vue`

- `loadPreview()` に AbortController を導入
- 新 fetch 開始時に \`previewAbort?.abort()\` + \`previewPdfData.value = null\`
- fetch / await 後に \`signal.aborted\` ガード
- `onUnmounted()` で進行中 fetch も abort

### テスト

`tests/utils/preview-fetch.test.ts` (5 test):

1. **out.buffer !== original** — clone 確認 (中心 assertion)
2. **signal で AbortError 伝搬** — controller.abort() で fetch が AbortError reject
3. **headers が fetch に転送される** — Authorization / X-Tenant-ID
4. **non-ok response で HTTP {status} throw**
5. **default `init={}`** — signal/headers なし呼び出しが通る

## 検証手順

1. CI 通過後、staging deploy
2. document detail で「マスク済 ↔ 原本 ↔ 再 redact」を高速連打
3. console に `Failed to execute 'postMessage' on 'Worker'` が出ないこと
4. `recomputeRedaction()` 中に WS event で `completed` が来てもエラー出ないこと

## 関連

- rust-alc-api PR #317 — 3164 消費税マスクズレ修正 (本 PR と並行)
- rust-alc-api PR #313 — 2-stage Gemini パイプライン