### PR TITLE
fix(preview): remove max-h + overflow so PDF shows in full without scrolling

### DIFF
--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -518,7 +518,7 @@ onUnmounted(() => {
         <ClientOnly v-else-if="previewPdfSource">
           <VuePdfEmbed
             :source="previewPdfSource"
-            class="bg-gray-50 rounded border max-h-[600px] overflow-y-auto"
+            class="bg-gray-50 rounded border"
             @loaded="onPdfLoaded"
             @loading-failed="onPdfError"
           />


### PR DESCRIPTION
ユーザー要望: notify-staging の document detail プレビューで PDF を
スクロールしないでいいようにしたい。

現状: \`<VuePdfEmbed class=\"bg-gray-50 rounded border max-h-[600px] overflow-y-auto\" />\`
で 600px に制限 + 内部スクロール → 縦長 PDF (3164 等) では全体が見えない。

修正: \`max-h-[600px] overflow-y-auto\` を削除。bg/rounded/border は維持。
全ページが縦に展開され、container 自体は overflow しない (= ページ全体の
スクロールに統合される)。