### PR TITLE
feat(documents): 連絡先 3 フィールド (会社/担当/電話) を運送情報セクションに表示

### DIFF
--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -16,6 +16,10 @@ interface LogisticsFields {
   loading_at?: string | null
   unloading_at?: string | null
   notes?: string | null
+  // 連絡先 3 フィールド (相手先のみ、自社は extract.rs 側で除外済)
+  contact_company?: string | null
+  contact_person?: string | null
+  contact_phone?: string | null
 }
 
 interface NotifyDocument {
@@ -101,9 +105,13 @@ const isPdf = computed(() => {
 })
 
 /**
- * 配車手配票から抽出した 5 フィールド (積地・卸地・積み日時・卸し日時・注意事項)。
+ * 配車手配票から抽出した 8 フィールド
+ * (積地・卸地・積み日時・卸し日時・注意事項・連絡先会社名・担当者・電話番号)。
  * バックエンドの `crates/alc-notify/src/extract.rs::LogisticsFields` と対応。
  * `extracted_data.logistics` が object のときのみ取り出す。
+ *
+ * 連絡先 3 フィールドは「相手先 (依頼元・お客様)」のみ抽出される。自社情報は
+ * tenants.name を Gemini プロンプトに渡して除外している。
  */
 const logisticsFields = computed<LogisticsFields | null>(() => {
   const d = document.value?.extracted_data
@@ -114,15 +122,22 @@ const logisticsFields = computed<LogisticsFields | null>(() => {
 })
 
 /**
- * 5 フィールドのうち 1 つでも非空なら true。
+ * 8 フィールドのうち 1 つでも非空なら true。
  * extract が完了して logistics データが揃ったかの UI 表示判定に使う。
  */
 const hasLogistics = computed(() => {
   const l = logisticsFields.value
   if (!l) return false
-  return [l.loading_place, l.unloading_place, l.loading_at, l.unloading_at, l.notes].some(
-    (v) => typeof v === 'string' && v.trim().length > 0,
-  )
+  return [
+    l.loading_place,
+    l.unloading_place,
+    l.loading_at,
+    l.unloading_at,
+    l.notes,
+    l.contact_company,
+    l.contact_person,
+    l.contact_phone,
+  ].some((v) => typeof v === 'string' && v.trim().length > 0)
 })
 
 /**
@@ -553,6 +568,24 @@ onUnmounted(() => {
             <template v-if="logisticsFields?.notes">
               <dt class="text-gray-500">⚠️ 注意</dt>
               <dd class="text-gray-900 whitespace-pre-wrap">{{ logisticsFields.notes }}</dd>
+            </template>
+            <!-- 連絡先 3 フィールド (相手先のみ、自社は extract 側で除外済) -->
+            <template v-if="logisticsFields?.contact_company">
+              <dt class="text-gray-500">🏢 連絡先</dt>
+              <dd class="text-gray-900">{{ logisticsFields.contact_company }}</dd>
+            </template>
+            <template v-if="logisticsFields?.contact_person">
+              <dt class="text-gray-500">👤 担当</dt>
+              <dd class="text-gray-900">{{ logisticsFields.contact_person }}</dd>
+            </template>
+            <template v-if="logisticsFields?.contact_phone">
+              <dt class="text-gray-500">📞 電話</dt>
+              <dd class="text-gray-900">
+                <a :href="`tel:${logisticsFields.contact_phone}`"
+                   class="text-blue-600 hover:underline">
+                  {{ logisticsFields.contact_phone }}
+                </a>
+              </dd>
             </template>
           </dl>
         </div>


### PR DESCRIPTION
rust-alc-api#320 で追加した 3 フィールド (contact_company / contact_person /
contact_phone) を `documents/[id].vue` の運送情報セクションに read-only で表示する。

これらは LINE 配信時の本文末尾にも列挙される (バック側で自社情報を除外済)。
電話番号は \`tel:\` リンクにして、ドライバーが UI から直接発信できるようにした。

## 表示順 (バック distribute.rs と同じ)

  📍 積地 / 📦 卸地 / 🕐 積込 / 🕓 卸し / ⚠️ 注意 /
  🏢 連絡先 / 👤 担当 / 📞 電話 (tel: リンク)

## 変更点

- \`LogisticsFields\` interface に 3 フィールド追加
- \`hasLogistics\` computed が 8 フィールドを評価するよう更新
- 詳細画面 dl に 3 つの template ブロック追加
- 電話番号は \`<a href="tel:...">\` で発信リンク化

## テスト

- vitest 91 件全 pass

## 関連 PR

- rust-alc-api#320 (バックエンド 3 フィールド + 自社除外) と同時 merge 推奨