### PR TITLE
feat(documents): 積地/卸地の住所+電話を場所セルにグループ表示

### DIFF
--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -12,7 +12,12 @@ const documentId = computed(() => String(route.params.id))
 
 interface LogisticsFields {
   loading_place?: string | null
+  // 積地に住所と電話が併記されている時のサブ情報 (rust-alc-api#321)
+  loading_place_address?: string | null
+  loading_place_phone?: string | null
   unloading_place?: string | null
+  unloading_place_address?: string | null
+  unloading_place_phone?: string | null
   loading_at?: string | null
   unloading_at?: string | null
   notes?: string | null
@@ -122,7 +127,7 @@ const logisticsFields = computed<LogisticsFields | null>(() => {
 })
 
 /**
- * 8 フィールドのうち 1 つでも非空なら true。
+ * 12 フィールドのうち 1 つでも非空なら true。
  * extract が完了して logistics データが揃ったかの UI 表示判定に使う。
  */
 const hasLogistics = computed(() => {
@@ -130,7 +135,11 @@ const hasLogistics = computed(() => {
   if (!l) return false
   return [
     l.loading_place,
+    l.loading_place_address,
+    l.loading_place_phone,
     l.unloading_place,
+    l.unloading_place_address,
+    l.unloading_place_phone,
     l.loading_at,
     l.unloading_at,
     l.notes,
@@ -549,13 +558,39 @@ onUnmounted(() => {
             この情報が LINE 配信時に本文へ載ります
           </p>
           <dl class="grid grid-cols-[7em_1fr] gap-y-1 text-sm">
-            <template v-if="logisticsFields?.loading_place">
+            <!-- 積地: 名前 + 住所 + 電話を縦に積む (PDF の表現と同じ並び) -->
+            <template v-if="logisticsFields?.loading_place || logisticsFields?.loading_place_address || logisticsFields?.loading_place_phone">
               <dt class="text-gray-500">📍 積地</dt>
-              <dd class="text-gray-900">{{ logisticsFields.loading_place }}</dd>
+              <dd class="text-gray-900">
+                <div v-if="logisticsFields?.loading_place">{{ logisticsFields.loading_place }}</div>
+                <div v-if="logisticsFields?.loading_place_address" class="text-xs text-gray-600">
+                  {{ logisticsFields.loading_place_address }}
+                </div>
+                <div v-if="logisticsFields?.loading_place_phone" class="text-xs">
+                  ☎
+                  <a :href="`tel:${logisticsFields.loading_place_phone}`"
+                     class="text-blue-600 hover:underline">
+                    {{ logisticsFields.loading_place_phone }}
+                  </a>
+                </div>
+              </dd>
             </template>
-            <template v-if="logisticsFields?.unloading_place">
+            <!-- 卸地: 同様に名前 + 住所 + 電話 -->
+            <template v-if="logisticsFields?.unloading_place || logisticsFields?.unloading_place_address || logisticsFields?.unloading_place_phone">
               <dt class="text-gray-500">📦 卸地</dt>
-              <dd class="text-gray-900">{{ logisticsFields.unloading_place }}</dd>
+              <dd class="text-gray-900">
+                <div v-if="logisticsFields?.unloading_place">{{ logisticsFields.unloading_place }}</div>
+                <div v-if="logisticsFields?.unloading_place_address" class="text-xs text-gray-600">
+                  {{ logisticsFields.unloading_place_address }}
+                </div>
+                <div v-if="logisticsFields?.unloading_place_phone" class="text-xs">
+                  ☎
+                  <a :href="`tel:${logisticsFields.unloading_place_phone}`"
+                     class="text-blue-600 hover:underline">
+                    {{ logisticsFields.unloading_place_phone }}
+                  </a>
+                </div>
+              </dd>
             </template>
             <template v-if="logisticsFields?.loading_at">
               <dt class="text-gray-500">🕐 積込</dt>


### PR DESCRIPTION
rust-alc-api#321 で追加された 4 フィールド (loading_place_address,
loading_place_phone, unloading_place_address, unloading_place_phone) を
詳細画面の運送情報セクションに表示する。

## UI 変更

積地/卸地の \`dd\` を拡張: 名前の下に住所と電話を縦積みで表示する。
電話は \`tel:\` リンクで発信可能。

\`\`\`
📍 積地  イオン関西RDC
        京都府乙訓郡大山崎町字大山崎小字鏡田38
        ☎ 075-959-5008
📦 卸地  熊本県八代市新港町3-9-8
\`\`\`

PDF 表現と同じ並び (会社名 → 住所 → 電話) で、ユーザーが LINE 受信本文と
詳細画面の構成を頭の中でマッピングしやすくなる。

## 変更点

- \`LogisticsFields\` interface に 4 フィールド追加
- \`hasLogistics\` computed が 12 フィールドを評価
- 積地/卸地の dl 行を多段表示に拡張
- 場所の電話番号も \`tel:\` リンク化 (連絡先電話と同じパターン)

## テスト

- vitest 91 件全 pass

## 関連 PR

- rust-alc-api#321 (バックエンド 4 フィールド + redact 改善) と同時 merge 推奨