### PR TITLE
Migrate notify_* secrets to CF Secrets Store binding

### DIFF
--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -40,6 +40,9 @@ jobs:
       has_staging_deploy: true
       # wrangler.toml が [[secrets_store_secrets]] を含むので secret-verify を opt-in
       # (Refs ippoan/ci-workflows#50 で wrangler Secrets Store binding 利用時の gate になった)
+      # wrangler_path を明示しないと root の wrangler.jsonc (Nuxt frontend 用、secrets 無し) を
+      # 読んでしまうので、worker の wrangler.toml を直接指定する。
+      wrangler_path: 'workers/email-receiver/wrangler.toml'
       gcp_secret_verify_project: cloudsql-sv
       gcp_secret_verify_provider: ${{ vars.GCP_WIF_PROVIDER }}
       gcp_secret_verify_sa: ${{ vars.GCP_WIF_SERVICE_ACCOUNT_STAGING }}

--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -18,6 +18,7 @@ permissions:
   contents: write
   pull-requests: write
   packages: read
+  id-token: write
 
 jobs:
   ci:
@@ -37,4 +38,9 @@ jobs:
       has_tests: true
       has_deploy: true
       has_staging_deploy: true
+      # wrangler.toml が [[secrets_store_secrets]] を含むので secret-verify を opt-in
+      # (Refs ippoan/ci-workflows#50 で wrangler Secrets Store binding 利用時の gate になった)
+      gcp_secret_verify_project: cloudsql-sv
+      gcp_secret_verify_provider: ${{ vars.GCP_WIF_PROVIDER }}
+      gcp_secret_verify_sa: ${{ vars.GCP_WIF_SERVICE_ACCOUNT_STAGING }}
     secrets: inherit

--- a/.github/workflows/realtime-bus-deploy.yml
+++ b/.github/workflows/realtime-bus-deploy.yml
@@ -18,6 +18,7 @@ permissions:
   contents: write
   pull-requests: write
   packages: read
+  id-token: write
 
 jobs:
   ci:
@@ -37,4 +38,9 @@ jobs:
       has_tests: true
       has_deploy: true
       has_staging_deploy: true
+      # wrangler.toml が [[secrets_store_secrets]] を含むので secret-verify を opt-in
+      # (Refs ippoan/ci-workflows#50 で wrangler Secrets Store binding 利用時の gate になった)
+      gcp_secret_verify_project: cloudsql-sv
+      gcp_secret_verify_provider: ${{ vars.GCP_WIF_PROVIDER }}
+      gcp_secret_verify_sa: ${{ vars.GCP_WIF_SERVICE_ACCOUNT_STAGING }}
     secrets: inherit

--- a/.github/workflows/realtime-bus-deploy.yml
+++ b/.github/workflows/realtime-bus-deploy.yml
@@ -40,6 +40,9 @@ jobs:
       has_staging_deploy: true
       # wrangler.toml が [[secrets_store_secrets]] を含むので secret-verify を opt-in
       # (Refs ippoan/ci-workflows#50 で wrangler Secrets Store binding 利用時の gate になった)
+      # wrangler_path を明示しないと root の wrangler.jsonc (Nuxt frontend 用、secrets 無し) を
+      # 読んでしまうので、worker の wrangler.toml を直接指定する。
+      wrangler_path: 'workers/realtime-bus/wrangler.toml'
       gcp_secret_verify_project: cloudsql-sv
       gcp_secret_verify_provider: ${{ vars.GCP_WIF_PROVIDER }}
       gcp_secret_verify_sa: ${{ vars.GCP_WIF_SERVICE_ACCOUNT_STAGING }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   pull-requests: write
   packages: read
+  id-token: write
 
 jobs:
   ci:

--- a/workers/email-receiver/wrangler.toml
+++ b/workers/email-receiver/wrangler.toml
@@ -18,9 +18,20 @@ head_sampling_rate = 1.0
 # tenant 識別は body の `tenant_slug` で backend が `tenants.slug` から解決する。
 # 認証は shared secret (NOTIFY_WORKER_SECRET) で経路保護のみ。
 #
-# 必須 secret (デプロイ前に投入):
-#   wrangler secret put NOTIFY_WORKER_SECRET           # prod 値 (Secret Manager: notify-worker-secret)
-#   wrangler secret put NOTIFY_WORKER_SECRET_STAGING   # staging 値 (Secret Manager: notify-worker-secret-staging)
+# secret は CF Secrets Store binding 経由で配布される (Refs ippoan/rust-alc-api#354)。
+# 値の更新は GCP Secret Manager に投入 → secrets-inventory が CF に伝播。
+# `wrangler secret put` は使わない (= per-worker env var だと
+# secrets-inventory get_drift から見えない false negative リスクがあるため)。
+
+[[secrets_store_secrets]]
+binding = "NOTIFY_WORKER_SECRET"
+store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
+secret_name = "notify-worker-secret"
+
+[[secrets_store_secrets]]
+binding = "NOTIFY_WORKER_SECRET_STAGING"
+store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
+secret_name = "notify-worker-secret-staging"
 
 [vars]
 INGEST_ENDPOINT = "https://alc-api.ippoan.org/api/notify/ingest"

--- a/workers/realtime-bus/wrangler.toml
+++ b/workers/realtime-bus/wrangler.toml
@@ -21,9 +21,18 @@ new_classes = ["RedactBus"]
 
 # 必須 secret (デプロイ前に投入):
 #   wrangler secret put JWT_SECRET                        # rust-alc-api と同値
-#   wrangler secret put NOTIFY_REDACT_BROADCAST_SECRET    # rust-alc-api と同値
 #   wrangler secret put JWT_SECRET --env staging
-#   wrangler secret put NOTIFY_REDACT_BROADCAST_SECRET --env staging
+#
+# NOTIFY_REDACT_BROADCAST_SECRET は CF Secrets Store binding 経由
+# (Refs ippoan/rust-alc-api#354)。値の更新は GCP Secret Manager に投入 →
+# secrets-inventory が CF に伝播。`wrangler secret put` は使わない
+# (= per-worker env var だと secrets-inventory get_drift から見えない
+# false negative リスクがあるため)。
+
+[[secrets_store_secrets]]
+binding = "NOTIFY_REDACT_BROADCAST_SECRET"
+store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
+secret_name = "notify-redact-broadcast-secret"
 
 [env.staging]
 name = "notify-realtime-bus-staging"
@@ -35,3 +44,8 @@ routes = [
 bindings = [
   { name = "REDACT_BUS", class_name = "RedactBus" }
 ]
+
+[[env.staging.secrets_store_secrets]]
+binding = "NOTIFY_REDACT_BROADCAST_SECRET"
+store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
+secret_name = "notify-redact-broadcast-secret-staging"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,12 @@
 	"assets": {
 		"directory": ".output/public"
 	},
+	// Nuxt frontend は runtime secret を持たない (config 値は public な NUXT_PUBLIC_*
+	// 環境変数のみ)。ippoan/ci-workflows の secret-verify gate を明示的に pass
+	// させるため、空 list を declare する (Refs ippoan/ci-workflows#50)。
+	"secrets": {
+		"required": []
+	},
 	"env": {
 		"staging": {
 			"name": "nuxt-notify-staging",


### PR DESCRIPTION
## Summary

`wrangler secret put` で配布していた notify_* 系 4 secret を CF Secrets Store の `[[secrets_store_secrets]]` binding に切り替える。

| binding | secret_name | store_id |
|---|---|---|
| `workers/email-receiver` `NOTIFY_WORKER_SECRET` | `notify-worker-secret` | `bd7bc91a3e5f4111add4acf6cb4b8733` |
| `workers/email-receiver` `NOTIFY_WORKER_SECRET_STAGING` | `notify-worker-secret-staging` | 同上 |
| `workers/realtime-bus` prod `NOTIFY_REDACT_BROADCAST_SECRET` | `notify-redact-broadcast-secret` | 同上 |
| `workers/realtime-bus` env.staging `NOTIFY_REDACT_BROADCAST_SECRET` | `notify-redact-broadcast-secret-staging` | 同上 |

`JWT_SECRET` は notify_* 系ではないので scope 外 (引き続き `wrangler secret put`)。

### 背景

`wrangler secret put` は per-worker env var で `secrets-inventory get_drift` から見えない (= 値変更を inventory が追えない false negative リスク)。Secrets Store binding は GCP→CF sync 経路 (= JWT_SECRET 等と同 pipeline) で機械的に管理できる。

### 事前準備 (完了済み)

GCP→CF Secrets Store sync は `secrets-inventory` 経由で実行済み:

```
POST /mcp/sync-from-gcp/notify-worker-secret?targets=cf                    -> created
POST /mcp/sync-from-gcp/notify-worker-secret-staging?targets=cf            -> created
POST /mcp/sync-from-gcp/notify-redact-broadcast-secret?targets=cf          -> created
POST /mcp/sync-from-gcp/notify-redact-broadcast-secret-staging?targets=cf  -> created
```

`get_drift` で 4 entry とも `in_cloudflare: true` を確認済み (`provider_counts.cloudflare`: 17 → 21)。

### deploy 後の clean-up

```
wrangler secret delete NOTIFY_WORKER_SECRET                      # email-receiver (prod)
wrangler secret delete NOTIFY_WORKER_SECRET_STAGING              # email-receiver (prod)
wrangler secret delete NOTIFY_REDACT_BROADCAST_SECRET            # realtime-bus (prod)
wrangler secret delete NOTIFY_REDACT_BROADCAST_SECRET --env staging   # realtime-bus (staging)
```

## Test plan

- [x] `python3 tomllib` で TOML 構文 OK
- [x] GCP→CF sync 4 entry すべて 200 created
- [x] `secrets-inventory get_drift` で notify_* 4 entry が drift list から消えた
- [ ] merge + deploy 後、email-receiver ingest endpoint に test request → 200 確認
- [ ] merge + deploy 後、rust-alc-api redact pipeline 経由で realtime-bus `/broadcast` が届く確認
- [ ] 確認後、上記 clean-up コマンドで旧 per-worker secret 削除

Refs ippoan/rust-alc-api#354
Refs ippoan/rust-alc-api#351
Refs ippoan/rust-alc-api#218

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZhUL9wivVAbSuTRLEAFkT)_