### PR TITLE
ci(realtime-bus): smoke /broadcast on staging after deploy

### DIFF
--- a/.github/workflows/realtime-bus-deploy.yml
+++ b/.github/workflows/realtime-bus-deploy.yml
@@ -47,3 +47,43 @@ jobs:
       gcp_secret_verify_provider: ${{ vars.GCP_WIF_PROVIDER }}
       gcp_secret_verify_sa: ${{ vars.GCP_WIF_SERVICE_ACCOUNT_STAGING }}
     secrets: inherit
+
+  # staging deploy 後、realtime-bus の /broadcast endpoint を実際に叩いて
+  # NOTIFY_REDACT_BROADCAST_SECRET_STAGING が CF Secrets Store binding 経由で
+  # 正しく注入されているかを確認する smoke test。
+  #
+  # 401 が返れば secret 不一致 (= GCP / CF Secrets Store / Worker binding のどこかで drift)。
+  # 200 / 204 が返れば auth 通過、CF Secrets Store の値で OK と判定する。
+  # subscribe している admin WS が 0 件でも broadcast 自体は no-op で成功する。
+  smoke-staging-broadcast:
+    name: Smoke /broadcast on staging
+    needs: ci
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST /broadcast with NOTIFY_REDACT_BROADCAST_SECRET_STAGING
+        env:
+          SECRET: ${{ secrets.NOTIFY_REDACT_BROADCAST_SECRET_STAGING }}
+        run: |
+          set -eu
+          if [ -z "${SECRET:-}" ]; then
+            echo "::error::NOTIFY_REDACT_BROADCAST_SECRET_STAGING is empty — check org secret sync (secrets-inventory sync-from-gcp ... ?targets=gh)"
+            exit 1
+          fi
+          http=$(curl -sS -o /tmp/body -w "%{http_code}" -X POST \
+            "https://realtime.notify-staging.ippoan.org/broadcast" \
+            -H "X-Broadcast-Secret: $SECRET" \
+            -H "Content-Type: application/json" \
+            --data-binary '{"tenant_id":"00000000-0000-0000-0000-000000000000","document_id":"ci-smoke","status":"completed"}')
+          echo "HTTP $http"
+          head -c 500 /tmp/body || true
+          echo
+          if [ "$http" = "401" ]; then
+            echo "::error::auth failed — NOTIFY_REDACT_BROADCAST_SECRET_STAGING in this repo does not match the value bound to realtime-bus (CF Secrets Store: notify-redact-broadcast-secret-staging). Check secrets-inventory get_drift."
+            exit 1
+          fi
+          if [ "$http" -lt 200 ] || [ "$http" -ge 400 ]; then
+            echo "::error::unexpected HTTP $http"
+            exit 1
+          fi
+          echo "::notice::broadcast accepted (HTTP $http) — secret OK"


### PR DESCRIPTION
## Summary

`realtime-bus-deploy.yml` に staging deploy 後の smoke job を 1 つ追加。`NOTIFY_REDACT_BROADCAST_SECRET_STAGING` (= rust-alc-api と realtime-bus の shared secret) が経路全体で揃っているかを CI で機械的に確認する。

## 確認の流れ

```
GitHub Actions secret NOTIFY_REDACT_BROADCAST_SECRET_STAGING
   └─ curl -X POST https://realtime.notify-staging.ippoan.org/broadcast
       -H "X-Broadcast-Secret: $SECRET"
       -d '{tenant_id, document_id, status}'
          │
          ▼
       realtime-bus-staging worker
         (CF Secrets Store binding NOTIFY_REDACT_BROADCAST_SECRET
          → secret_name: notify-redact-broadcast-secret-staging)
          │
          ▼
       constantTimeEqualStr(provided, expected)
          │
          ├── true  → 200 (DO に dispatch、subscribe 0 でも no-op で通る)
          └── false → 401
```

| HTTP | 判定 |
|---|---|
| `200-399` | secret OK |
| `401` | secret drift (GCP / CF Secrets Store / worker binding / GitHub org secret のどこかで不一致) — fail |
| その他 | unexpected — fail |

## 事前準備 (完了済み)

org secret `NOTIFY_REDACT_BROADCAST_SECRET_STAGING` は secrets-inventory 経由で GCP から push 済み:

```
POST /mcp/sync-from-gcp/notify-redact-broadcast-secret-staging?targets=gh&gh_name=NOTIFY_REDACT_BROADCAST_SECRET_STAGING&visibility=all -> 200 ok
```

値は LLM context を経由していない。

## なぜ smoke が必要か

`secret-verify` は GCP 側に secret が **存在** することと **wrangler に binding が宣言** されていることまでしか確認しない。実際に CF Secrets Store の **値** が worker runtime に届いていることまでは検証しない (binding が壊れていても deploy は通る)。この smoke は最後の onee mile を CI で押さえる。

## test plan

- [x] yaml syntax OK (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] PR で deploy_staging → smoke が走る
- [ ] smoke で 200/204 が返り pass
- [ ] (negative test、optional) わざと secret を壊して 401 で fail することを確認

## follow-up (別 PR)

- rust-alc-api 側に `NOTIFY_WORKER_SECRET_STAGING` で `/api/notify/ingest` を叩く同種 smoke を追加 (email-receiver は HTTP 入口がないため backend 側で検証する)

Refs ippoan/rust-alc-api#354

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZhUL9wivVAbSuTRLEAFkT)_