### PR TITLE
ci: drop wrangler_path (not defined in frontend-ci.yml@main)

### DIFF
--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -40,9 +40,12 @@ jobs:
       has_staging_deploy: true
       # wrangler.toml が [[secrets_store_secrets]] を含むので secret-verify を opt-in
       # (Refs ippoan/ci-workflows#50 で wrangler Secrets Store binding 利用時の gate になった)
-      # wrangler_path を明示しないと root の wrangler.jsonc (Nuxt frontend 用、secrets 無し) を
-      # 読んでしまうので、worker の wrangler.toml を直接指定する。
-      wrangler_path: 'workers/email-receiver/wrangler.toml'
+      # 注: frontend-ci.yml は wrangler_path 入力を持たないため (= startup_failure
+      # になる) ここでは指定しない。secret-verify-gcp は autodetect で root の
+      # wrangler.jsonc を読むが、root 側に "secrets": {"required": []} が宣言済み
+      # なので gate は pass する (Nuxt frontend は実 secret を持たない設計)。
+      # ippoan/ci-workflows に wrangler_path pass-through を追加したら、その時点で
+      # worker の toml を直接参照する形に切り替える。
       gcp_secret_verify_project: cloudsql-sv
       gcp_secret_verify_provider: ${{ vars.GCP_WIF_PROVIDER }}
       gcp_secret_verify_sa: ${{ vars.GCP_WIF_SERVICE_ACCOUNT_STAGING }}

--- a/.github/workflows/realtime-bus-deploy.yml
+++ b/.github/workflows/realtime-bus-deploy.yml
@@ -40,9 +40,12 @@ jobs:
       has_staging_deploy: true
       # wrangler.toml が [[secrets_store_secrets]] を含むので secret-verify を opt-in
       # (Refs ippoan/ci-workflows#50 で wrangler Secrets Store binding 利用時の gate になった)
-      # wrangler_path を明示しないと root の wrangler.jsonc (Nuxt frontend 用、secrets 無し) を
-      # 読んでしまうので、worker の wrangler.toml を直接指定する。
-      wrangler_path: 'workers/realtime-bus/wrangler.toml'
+      # 注: frontend-ci.yml は wrangler_path 入力を持たないため (= startup_failure
+      # になる) ここでは指定しない。secret-verify-gcp は autodetect で root の
+      # wrangler.jsonc を読むが、root 側に "secrets": {"required": []} が宣言済み
+      # なので gate は pass する (Nuxt frontend は実 secret を持たない設計)。
+      # ippoan/ci-workflows に wrangler_path pass-through を追加したら、その時点で
+      # worker の toml を直接参照する形に切り替える。
       gcp_secret_verify_project: cloudsql-sv
       gcp_secret_verify_provider: ${{ vars.GCP_WIF_PROVIDER }}
       gcp_secret_verify_sa: ${{ vars.GCP_WIF_SERVICE_ACCOUNT_STAGING }}


### PR DESCRIPTION
## Summary

PR #72 が `wrangler_path: 'workers/<name>/wrangler.toml'` を `frontend-ci.yml` の caller として渡したが、`frontend-ci.yml@main` は **この input を pass-through していない** (= 受け取れない)。

結果、GitHub Actions が workflow を registration phase で reject:

```
.github/workflows/realtime-bus-deploy.yml (Line: 45, Col: 22):
  Invalid input, wrangler_path is not defined in the referenced workflow.
```

これにより毎 push で 0-job startup_failure (2 秒完了) が発生中。PR #72 自体も実は startup_failure のまま merge された (CI panel での見え方が通常 fail と違うため見落とした)。

## 修正

両 worker caller の `wrangler_path: ...` 行を削除。`secret-verify-gcp` は autodetect で root の `wrangler.jsonc` を読みに行くが、root 側には PR #72 で `"secrets": { "required": [] }` を明示宣言済みのため gate は vacuous pass。

## トレードオフ

`ci-workflows` に `wrangler_path` の pass-through が入るまでの間、`secret-verify-gcp` は worker の `wrangler.toml` 内の `[[secrets_store_secrets]].secret_name` を GCP と cross-check しない (root のみ参照)。

カバーする他のレイヤ:
- **PR #73 の smoke** (`/broadcast` を実 secret で叩く) → binding drift を end-to-end で検出
- **secrets-inventory `get_drift`** → GCP / CF / GH 3 system の名前 inventory diff

このリグレッションは pass-through が ci-workflows に入った時点で revert する。

## test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` 両 file 構文 OK
- [x] `grep wrangler_path:` で実値の行が無いことを確認 (comment のみ残存)
- [ ] PR が startup_failure ではなく実 job を起動して走ることを確認

Refs ippoan/rust-alc-api#354
Refs ippoan/ci-workflows#50

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZhUL9wivVAbSuTRLEAFkT)_