### PR TITLE
ci: report Release Wave compatibility against rust-alc-api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,8 @@ jobs:
       has_integration: true
       integration_test_command: 'npx vitest run tests/integration/'
       integration_env: 'API_BASE_URL=http://localhost:18080'
+      # Release Wave compatibility: integration test green 時に
+      # 「nuxt-notify が rust-alc-api の現 prod image を相手に test した」ことを
+      # ci-dashboard に記録する (Refs ippoan/ci-dashboard#157)。
+      compat_backend_repo: ippoan/rust-alc-api
     secrets: inherit


### PR DESCRIPTION
## 概要

Release Wave compatibility (frontend ↔ backend image 突合, `ippoan/ci-dashboard#157`) の frontend consumer 配線の **end-to-end 検証台**。

keystone (`ippoan/ci-workflows#67`, merged) が提供する opt-in 入力 `compat_backend_repo` を指定する 1 行の caller 変更。

nuxt-notify を検証台に選んだ理由: Secrets Store 移行済み・`secret-verify` が root の `wrangler.jsonc` を検出して pass・`id-token: write` 宣言済み・rust-alc-api (`API_BASE_URL=http://localhost:18080`) 相手に integration test するため、追加の permission 変更なしで CI が green になる。

## 変更

`.github/workflows/test.yml` の `frontend-ci.yml` caller に追加:

```yaml
compat_backend_repo: ippoan/rust-alc-api
```

integration test green 時に `report-frontend-compat` action が ci-dashboard の `frontend-test-report` webhook を打ち、`frontend::ippoan/nuxt-notify` の `tested_against` に「rust-alc-api の現 prod image」を記録する。`RELEASE_WAVE_WEBHOOK_SECRET` は `secrets: inherit` 経由。backend record が無い初回は report 側が no-op になるため CI は壊さない。

## 効果 / 検証ポイント

- CI green 後、ci-dashboard 上で `frontend::ippoan/nuxt-notify` の compatibility 記録が確認できれば、keystone → consumer の配線が end-to-end で機能していることの確認になる。
- Release Wave 起動時の matrix で nuxt-notify が現 production の rust-alc-api image を test 済みかが緑/赤で可視化される。

Refs ippoan/ci-dashboard#157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_