### PR TITLE
ci: pin integration test to the recorded backend SHA (truthful compat)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,8 @@ jobs:
       # 「nuxt-notify が rust-alc-api の現 prod image を相手に test した」ことを
       # ci-dashboard に記録する (Refs ippoan/ci-dashboard#157)。
       compat_backend_repo: ippoan/rust-alc-api
+      # docker-compose.test.yml は ${API_IMAGE:-…:dev} で backend image を読む。
+      # frontend-ci がここに記録対象 SHA (ghcr.io/ippoan/rust-alc-api:<sha>) を
+      # 注入し、test した image == 記録 SHA を保証する (truthful 突合)。
+      compat_backend_image_env: API_IMAGE
     secrets: inherit


### PR DESCRIPTION
## 概要

item 2 (truthful 突合) の reference 配線。`ippoan/ci-workflows#69` で入った `compat_backend_image_env` を指定し、integration test を **記録対象の backend SHA と同じ image** で走らせる。

## 変更

`.github/workflows/test.yml` の caller に追加:

```yaml
compat_backend_image_env: API_IMAGE
```

`docker-compose.test.yml` は既に `image: ${API_IMAGE:-ghcr.io/ippoan/rust-alc-api:dev}` でパラメータ化済み。frontend-ci が integration test 前に記録対象 SHA を解決して `API_IMAGE=ghcr.io/ippoan/rust-alc-api:<sha>` を export するため、**test した image == ci-dashboard に記録される SHA** が保証される(従来は `:dev` で test しつつ別途取得した SHA を記録する近似だった)。

compose 変更は不要(既に env 化済)。

Refs ippoan/ci-dashboard#157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_