### PR TITLE
ci: add release-wave.yml handler caller

### DIFF
--- a/.github/workflows/release-wave.yml
+++ b/.github/workflows/release-wave.yml
@@ -1,0 +1,30 @@
+name: Release Wave
+
+# Release Wave 機構の caller (薄い ~10 行 wrapper)。
+# ci-dashboard から repository_dispatch で stage / flip / rollback event を
+# 受けて、ci-workflows の release-wave-handler.yml reusable に処理を委譲する。
+#
+# 親 issue: ippoan/ci-dashboard#137 / #237
+# Reusable: ippoan/ci-workflows/.github/workflows/release-wave-handler.yml
+# Repo config: ippoan/ci-workflows/config/release-wave-targets.yaml の
+#              `ippoan/nuxt-notify` entry (platform=cloudflare-workers, monorepo 3 unit)
+
+on:
+  repository_dispatch:
+    types:
+      - release-wave-stage
+      - release-wave-flip
+      - release-wave-rollback
+      - release-wave-traffic-rollback   # frontend 単独 rollback (cloudflare-workers)
+      - release-wave-backend-rollback    # backend 単独 rollback (cloudrun)
+
+permissions:
+  contents: write     # tag push (stage 時)
+  id-token: write     # WIF (cloudrun path 用、本 repo は CF だが reusable
+                      # parse 時 caller permissions check が要る)
+  packages: read      # @ippoan/* GitHub Packages dep install (npm_scope=@ippoan)
+
+jobs:
+  handler:
+    uses: ippoan/ci-workflows/.github/workflows/release-wave-handler.yml@main
+    secrets: inherit


### PR DESCRIPTION
## 背景

ippoan/ci-dashboard#237: Release Wave で各 repo の **stage が pending のまま進まない** root cause 調査の一環。

ci-dashboard は wave start 時に `release-wave-stage` を各 repo へ `repository_dispatch` で送るが、本 repo には handler caller (`release-wave.yml`) が存在せず **dispatch が no-op** になっていた。`release-wave-retest.yml` (retest 受け口) は追加済みだったが、肝心の stage/flip/rollback caller が欠落していた。そのため stage callback が一度も飛ばず stage が `pending` 固定になっていた。

## 変更

auth-worker と同じ ~10 行の caller を追加。`stage` / `flip` / `rollback` 系 dispatch を `ci-workflows/.github/workflows/release-wave-handler.yml@main` に委譲する。

本 repo は `release-wave-targets.yaml` で **platform=cloudflare-workers (monorepo 3 unit: app / email-receiver / realtime-bus)**。workers の stage は `wrangler versions upload` で no-traffic preview を上げ、preview URL reachability 確認後に stage-report callback する。

Refs ippoan/ci-dashboard#237 Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_