### PR TITLE
chore(observability): enable Workers Logs on realtime-bus and nuxt-notify

### DIFF
--- a/workers/realtime-bus/wrangler.toml
+++ b/workers/realtime-bus/wrangler.toml
@@ -3,6 +3,13 @@ main = "src/index.ts"
 compatibility_date = "2026-04-01"
 account_id = "24b45709d060d957340180e995f0d373"
 
+# Worker のリクエスト/イベントログを Cloudflare Dashboard の Observability タブに保存。
+# /broadcast 到着時刻と DO fan-out 件数を計測するため (Refs #71)。
+# observability は inheritable key なので env.staging にも継承される。
+[observability]
+enabled = true
+head_sampling_rate = 1.0
+
 # 本番ルート: realtime.notify.ippoan.org
 # rust-alc-api (NOTIFY_REDACT_BROADCAST_URL) → /broadcast
 # admin ブラウザ (Sec-WebSocket-Protocol JWT) → /subscribe

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,12 @@
 	"assets": {
 		"directory": ".output/public"
 	},
+	// SSR 側 fetch の時刻・status を Cloudflare Dashboard の Observability タブに保存
+	// (Refs #71)。observability は inheritable key なので env.staging にも継承される。
+	"observability": {
+		"enabled": true,
+		"head_sampling_rate": 1
+	},
 	// Nuxt frontend は runtime secret を持たない (config 値は public な NUXT_PUBLIC_*
 	// 環境変数のみ)。ippoan/ci-workflows の secret-verify gate を明示的に pass
 	// させるため、空 list を declare する (Refs ippoan/ci-workflows#50)。


### PR DESCRIPTION
## 概要

#71 の調査タスク 2「Cloudflare 側 observability を全 Worker で有効化」を実施。

`notify-email-receiver` は既に `[observability]` 有効済みだったので、残る 2 つに追加して全 Worker を揃える:

- `workers/realtime-bus/wrangler.toml` — `[observability]` 追加 (→ `/broadcast` 到着時刻・DO fan-out 件数が見える)
- `wrangler.jsonc` (nuxt-notify SSR) — `observability` 追加 (→ SSR fetch の時刻・status が見える)

いずれも `enabled: true` / `head_sampling_rate: 1` (全件)。`observability` は wrangler の inheritable key なので、トップレベル宣言で `env.staging` にも継承される (prod / staging 両方で有効)。

## これで何が見えるか

Cloudflare Dashboard の Observability タブから直近 7 日のログを Query Builder で検索可能になる:
- `notify-email-receiver`: ingest fetch の duration p95 (既存)
- `notify-realtime-bus`: `/broadcast` から `/dispatch` までの時刻差、fan-out 件数
- `nuxt-notify`: SSR 側 fetch の時刻・status

## スコープ外 (#71 で別途)

- rust-alc-api 側の stage 別計測 (Gemini / PDF render / R2) — 別 repo・別 issue
- Logpush (現時点では 7 日内ダッシュボード閲覧で足りる)

Refs #71

---
_Generated by [Claude Code](https://claude.ai/code/session_018dUHPkdEV4dqJZqKgemo2E)_