### PR TITLE
refactor(documents): DocumentCard 部品化 + バッジ/format ヘルパ共通化 (Refs #69)

### DIFF
--- a/app/components/DocumentCard.vue
+++ b/app/components/DocumentCard.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import {
+  extractionBadge,
+  distributionBadge,
+  redactionBadge,
+  type BadgeView,
+  type DocumentCardData,
+} from '~/utils/documentBadges'
+
+// 共通ドキュメントカード (Refs #69)。
+// ダッシュボード一覧で使う rich カード。タイトル / 概要 / 送信者・日時 +
+// redaction / extraction / distribution の 3 バッジを描画する。
+// バッジ系は値が無いとき (extraction_status / distribution_status が未指定)
+// は描画しないので、フィールドが揃わない呼び出し元 (メール詳細 = backend
+// レスポンス拡張待ち) でも壊れない。
+//
+// アクション (redact / 非表示 / 削除 / ダウンロード等) は呼び出し元固有なので
+// `#actions` slot に委ねる。カード本体クリックの遷移先は `to` prop。
+// DocumentCardData 型は ~/utils/documentBadges で single-source。
+
+const props = withDefaults(
+  defineProps<{
+    doc: DocumentCardData
+    /** カード本体クリックの遷移先。未指定ならリンクにしない (div 描画)。 */
+    to?: string | null
+    /** 非表示中など薄く表示したいとき。 */
+    dimmed?: boolean
+  }>(),
+  { to: null, dimmed: false },
+)
+
+const title = computed(
+  () => props.doc.extracted_title || props.doc.file_name || 'Untitled',
+)
+const subtitle = computed(
+  () => props.doc.extracted_summary || props.doc.source_subject || '',
+)
+const redaction = computed<BadgeView | null>(() => redactionBadge(props.doc))
+const dateLabel = computed(() =>
+  new Date(props.doc.created_at).toLocaleString('ja-JP'),
+)
+</script>
+
+<template>
+  <div
+    :class="[
+      'bg-white rounded-lg shadow border hover:bg-gray-50 transition',
+      dimmed ? 'opacity-60' : '',
+    ]"
+  >
+    <component
+      :is="to ? resolveComponent('NuxtLink') : 'div'"
+      :to="to ?? undefined"
+      class="block p-4"
+    >
+      <div class="flex justify-between items-start gap-3">
+        <div class="min-w-0 flex-1">
+          <h3 class="font-semibold truncate">{{ title }}</h3>
+          <p class="text-sm text-gray-500 mt-1 truncate">{{ subtitle }}</p>
+          <p class="text-xs text-gray-400 mt-1">
+            {{ doc.source_sender }} · {{ dateLabel }}
+          </p>
+        </div>
+        <div class="flex gap-2 flex-shrink-0 flex-wrap justify-end">
+          <span
+            v-if="redaction"
+            :class="['px-2 py-0.5 text-xs rounded-full', redaction.cls]"
+          >
+            {{ redaction.label }}
+          </span>
+          <span
+            v-if="doc.extraction_status"
+            :class="['px-2 py-0.5 text-xs rounded-full', extractionBadge(doc.extraction_status).cls]"
+          >
+            {{ extractionBadge(doc.extraction_status).label }}
+          </span>
+          <span
+            v-if="doc.distribution_status"
+            :class="['px-2 py-0.5 text-xs rounded-full', distributionBadge(doc.distribution_status).cls]"
+          >
+            {{ distributionBadge(doc.distribution_status).label }}
+          </span>
+        </div>
+      </div>
+    </component>
+
+    <div v-if="$slots.actions" class="px-4 pb-3 -mt-1 flex items-center gap-2 flex-wrap">
+      <slot name="actions" />
+    </div>
+  </div>
+</template>

--- a/app/pages/emails/[id].vue
+++ b/app/pages/emails/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAuth } from '@ippoan/auth-client'
+import { formatSize, formatDate, deliveryStatusLabel } from '~/utils/documentBadges'
 
 const route = useRoute()
 const router = useRouter()
@@ -123,37 +124,6 @@ async function deleteDoc(doc: EmailDocument) {
     alert(`削除失敗: ${e.message ?? e}`)
   } finally {
     deleting.value[doc.id] = false
-  }
-}
-
-function formatSize(bytes: number | null): string {
-  if (!bytes) return '-'
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
-}
-
-function formatDate(s: string | null): string {
-  if (!s) return '-'
-  return new Date(s).toLocaleString('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-}
-
-function deliveryStatusLabel(status: string): { label: string; cls: string } {
-  switch (status) {
-    case 'sent':
-      return { label: '送信済', cls: 'bg-green-100 text-green-700' }
-    case 'failed':
-      return { label: '失敗', cls: 'bg-red-100 text-red-700' }
-    case 'pending':
-      return { label: '未送信', cls: 'bg-gray-100 text-gray-700' }
-    default:
-      return { label: status, cls: 'bg-gray-100 text-gray-700' }
   }
 }
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -172,60 +172,6 @@ onRedactUpdate((ev) => {
     doc.redactions_applied = ev.redactions_applied
   }
 })
-
-function extractionBadge(status: string): { label: string; cls: string } {
-  switch (status) {
-    case 'completed':
-      return { label: '抽出済', cls: 'bg-green-100 text-green-700' }
-    case 'failed':
-      return { label: '抽出失敗', cls: 'bg-red-100 text-red-700' }
-    case 'pending':
-      return { label: '抽出待ち', cls: 'bg-yellow-100 text-yellow-700' }
-    default:
-      return { label: status, cls: 'bg-gray-100 text-gray-600' }
-  }
-}
-
-function distributionBadge(status: string): { label: string; cls: string } {
-  switch (status) {
-    case 'completed':
-      return { label: '配信済', cls: 'bg-green-100 text-green-700' }
-    case 'in_progress':
-      return { label: '配信中', cls: 'bg-blue-100 text-blue-700' }
-    case 'failed':
-      return { label: '配信失敗', cls: 'bg-red-100 text-red-700' }
-    default:
-      return { label: '未配信', cls: 'bg-gray-100 text-gray-600' }
-  }
-}
-
-// redaction_status: PDF アップロード時に async で金額マスク (migration 109)。
-// completed / skipped 以外は配信時に backend で 400 ブロックされる。
-// 注: PR #314 が production にデプロイされる前は API が redaction_status を
-//     返さない (undefined) → 「マスク待ち」扱いで PDF にだけバッジ表示する。
-function redactionBadge(doc: NotifyDocument): { label: string; cls: string } | null {
-  const isPdf = (doc.file_name ?? '').toLowerCase().endsWith('.pdf')
-  switch (doc.redaction_status) {
-    case 'completed':
-      return {
-        label: doc.redactions_applied != null ? `🔒 ${doc.redactions_applied}箇所` : '🔒 マスク済',
-        cls: 'bg-emerald-100 text-emerald-700',
-      }
-    case 'processing':
-      return { label: '🔄 マスク処理中', cls: 'bg-blue-100 text-blue-700' }
-    case 'failed':
-      return { label: '⚠️ マスク失敗', cls: 'bg-red-100 text-red-700' }
-    case 'pending':
-      return isPdf ? { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' } : null
-    case 'skipped':
-      // PDF 以外は表示しない (ノイズ削減)
-      return null
-    default:
-      // undefined: PR #314 未デプロイの API レスポンス。
-      // PDF だけ「マスク待ち」を出して Phase 3 移行を促す。
-      return isPdf ? { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' } : null
-  }
-}
 </script>
 
 <template>
@@ -283,35 +229,11 @@ function redactionBadge(doc: NotifyDocument): { label: string; cls: string } | n
     </div>
 
     <div v-else class="space-y-3">
-      <div v-for="doc in visibleDocuments" :key="doc.id"
-           :class="['bg-white rounded-lg shadow border hover:bg-gray-50 transition',
-                    hiddenIds.has(doc.id) ? 'opacity-60' : '']">
-        <NuxtLink :to="`/documents/${doc.id}`" class="block p-4">
-          <div class="flex justify-between items-start gap-3">
-            <div class="min-w-0 flex-1">
-              <h3 class="font-semibold truncate">{{ doc.extracted_title || doc.file_name || 'Untitled' }}</h3>
-              <p class="text-sm text-gray-500 mt-1 truncate">{{ doc.extracted_summary || doc.source_subject }}</p>
-              <p class="text-xs text-gray-400 mt-1">
-                {{ doc.source_sender }} · {{ new Date(doc.created_at).toLocaleString('ja-JP') }}
-              </p>
-            </div>
-            <div class="flex gap-2 flex-shrink-0 flex-wrap justify-end">
-              <span v-if="redactionBadge(doc)"
-                    :class="['px-2 py-0.5 text-xs rounded-full', redactionBadge(doc)!.cls]">
-                {{ redactionBadge(doc)!.label }}
-              </span>
-              <span :class="['px-2 py-0.5 text-xs rounded-full', extractionBadge(doc.extraction_status).cls]">
-                {{ extractionBadge(doc.extraction_status).label }}
-              </span>
-              <span :class="['px-2 py-0.5 text-xs rounded-full', distributionBadge(doc.distribution_status).cls]">
-                {{ distributionBadge(doc.distribution_status).label }}
-              </span>
-            </div>
-          </div>
-        </NuxtLink>
-
-        <!-- アクション行: 個別 redact (未処理 PDF のみ) + 非表示 + 削除 -->
-        <div class="px-4 pb-3 -mt-1 flex items-center gap-2 flex-wrap">
+      <DocumentCard v-for="doc in visibleDocuments" :key="doc.id"
+                    :doc="doc"
+                    :to="`/documents/${doc.id}`"
+                    :dimmed="hiddenIds.has(doc.id)">
+        <template #actions>
           <!-- 未処理 PDF は個別 redact 開始ボタンを表示。
                (undefined / pending / failed の PDF が対象) -->
           <button v-if="['pending', 'failed', undefined].includes(doc.redaction_status as any)
@@ -335,8 +257,8 @@ function redactionBadge(doc: NotifyDocument): { label: string; cls: string } | n
               {{ deletingIds.has(doc.id) ? '削除中…' : '🗑 削除' }}
             </button>
           </div>
-        </div>
-      </div>
+        </template>
+      </DocumentCard>
     </div>
   </div>
 </template>

--- a/app/utils/documentBadges.ts
+++ b/app/utils/documentBadges.ts
@@ -1,0 +1,115 @@
+// ドキュメントカード共通のバッジ / フォーマットヘルパ (Refs #69)。
+//
+// ダッシュボード一覧 (app/pages/index.vue) と DocumentCard / メール詳細
+// (app/pages/emails/[id].vue) で共有する。表示ロジックを 1 箇所に集約し、
+// 画面間で見た目・文言を揃えるための単一の出所。
+
+export interface BadgeView {
+  label: string
+  cls: string
+}
+
+/** redactionBadge が必要とする最小フィールド (NotifyDocument のサブセット)。 */
+export interface RedactionBadgeInput {
+  file_name: string | null
+  redaction_status?: string
+  redactions_applied?: number | null
+}
+
+/** DocumentCard.vue が描画に使うドキュメントの形 (rich フィールドは任意)。 */
+export interface DocumentCardData extends RedactionBadgeInput {
+  id: string
+  extracted_title?: string | null
+  extracted_summary?: string | null
+  source_sender?: string | null
+  source_subject?: string | null
+  created_at: string
+  extraction_status?: string
+  distribution_status?: string
+}
+
+export function extractionBadge(status: string): BadgeView {
+  switch (status) {
+    case 'completed':
+      return { label: '抽出済', cls: 'bg-green-100 text-green-700' }
+    case 'failed':
+      return { label: '抽出失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return { label: '抽出待ち', cls: 'bg-yellow-100 text-yellow-700' }
+    default:
+      return { label: status, cls: 'bg-gray-100 text-gray-600' }
+  }
+}
+
+export function distributionBadge(status: string): BadgeView {
+  switch (status) {
+    case 'completed':
+      return { label: '配信済', cls: 'bg-green-100 text-green-700' }
+    case 'in_progress':
+      return { label: '配信中', cls: 'bg-blue-100 text-blue-700' }
+    case 'failed':
+      return { label: '配信失敗', cls: 'bg-red-100 text-red-700' }
+    default:
+      return { label: '未配信', cls: 'bg-gray-100 text-gray-600' }
+  }
+}
+
+// redaction_status: PDF アップロード時に async で金額マスク (migration 109)。
+// completed / skipped 以外は配信時に backend で 400 ブロックされる。
+// 注: PR #314 が production にデプロイされる前は API が redaction_status を
+//     返さない (undefined) → 「マスク待ち」扱いで PDF にだけバッジ表示する。
+export function redactionBadge(doc: RedactionBadgeInput): BadgeView | null {
+  const isPdf = (doc.file_name ?? '').toLowerCase().endsWith('.pdf')
+  switch (doc.redaction_status) {
+    case 'completed':
+      return {
+        label: doc.redactions_applied != null ? `🔒 ${doc.redactions_applied}箇所` : '🔒 マスク済',
+        cls: 'bg-emerald-100 text-emerald-700',
+      }
+    case 'processing':
+      return { label: '🔄 マスク処理中', cls: 'bg-blue-100 text-blue-700' }
+    case 'failed':
+      return { label: '⚠️ マスク失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return isPdf ? { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' } : null
+    case 'skipped':
+      // PDF 以外は表示しない (ノイズ削減)
+      return null
+    default:
+      // undefined: PR #314 未デプロイの API レスポンス。
+      // PDF だけ「マスク待ち」を出して Phase 3 移行を促す。
+      return isPdf ? { label: 'マスク待ち', cls: 'bg-gray-100 text-gray-600' } : null
+  }
+}
+
+/** 配信履歴テーブルの状態バッジ (メール詳細)。 */
+export function deliveryStatusLabel(status: string): BadgeView {
+  switch (status) {
+    case 'sent':
+      return { label: '送信済', cls: 'bg-green-100 text-green-700' }
+    case 'failed':
+      return { label: '失敗', cls: 'bg-red-100 text-red-700' }
+    case 'pending':
+      return { label: '未送信', cls: 'bg-gray-100 text-gray-700' }
+    default:
+      return { label: status, cls: 'bg-gray-100 text-gray-700' }
+  }
+}
+
+export function formatSize(bytes: number | null): string {
+  if (!bytes) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+export function formatDate(s: string | null): string {
+  if (!s) return '-'
+  return new Date(s).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}

--- a/tests/utils/documentBadges.test.ts
+++ b/tests/utils/documentBadges.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractionBadge,
+  distributionBadge,
+  redactionBadge,
+  deliveryStatusLabel,
+  formatSize,
+  formatDate,
+} from '../../app/utils/documentBadges'
+
+describe('extractionBadge', () => {
+  it('既知ステータス', () => {
+    expect(extractionBadge('completed').label).toBe('抽出済')
+    expect(extractionBadge('failed').label).toBe('抽出失敗')
+    expect(extractionBadge('pending').label).toBe('抽出待ち')
+  })
+  it('未知ステータスは raw label', () => {
+    const b = extractionBadge('weird')
+    expect(b.label).toBe('weird')
+    expect(b.cls).toContain('gray')
+  })
+})
+
+describe('distributionBadge', () => {
+  it('既知ステータス', () => {
+    expect(distributionBadge('completed').label).toBe('配信済')
+    expect(distributionBadge('in_progress').label).toBe('配信中')
+    expect(distributionBadge('failed').label).toBe('配信失敗')
+  })
+  it('未知ステータスは未配信', () => {
+    expect(distributionBadge('xyz').label).toBe('未配信')
+  })
+})
+
+describe('redactionBadge', () => {
+  it('completed: 件数あり / なし', () => {
+    expect(redactionBadge({ file_name: 'a.pdf', redaction_status: 'completed', redactions_applied: 3 })!.label)
+      .toBe('🔒 3箇所')
+    expect(redactionBadge({ file_name: 'a.pdf', redaction_status: 'completed', redactions_applied: null })!.label)
+      .toBe('🔒 マスク済')
+  })
+  it('processing / failed', () => {
+    expect(redactionBadge({ file_name: 'a.pdf', redaction_status: 'processing' })!.label).toBe('🔄 マスク処理中')
+    expect(redactionBadge({ file_name: 'a.pdf', redaction_status: 'failed' })!.label).toBe('⚠️ マスク失敗')
+  })
+  it('pending: PDF はマスク待ち / 非PDF は null', () => {
+    expect(redactionBadge({ file_name: 'a.pdf', redaction_status: 'pending' })!.label).toBe('マスク待ち')
+    expect(redactionBadge({ file_name: 'a.png', redaction_status: 'pending' })).toBeNull()
+  })
+  it('skipped は常に null', () => {
+    expect(redactionBadge({ file_name: 'a.pdf', redaction_status: 'skipped' })).toBeNull()
+  })
+  it('undefined (未デプロイ): PDF はマスク待ち / 非PDF は null', () => {
+    expect(redactionBadge({ file_name: 'a.pdf' })!.label).toBe('マスク待ち')
+    expect(redactionBadge({ file_name: 'a.docx' })).toBeNull()
+  })
+  it('file_name null は非PDF扱いで null', () => {
+    expect(redactionBadge({ file_name: null, redaction_status: 'pending' })).toBeNull()
+  })
+})
+
+describe('deliveryStatusLabel', () => {
+  it('既知ステータス', () => {
+    expect(deliveryStatusLabel('sent').label).toBe('送信済')
+    expect(deliveryStatusLabel('failed').label).toBe('失敗')
+    expect(deliveryStatusLabel('pending').label).toBe('未送信')
+  })
+  it('未知ステータスは raw label', () => {
+    expect(deliveryStatusLabel('queued').label).toBe('queued')
+  })
+})
+
+describe('formatSize', () => {
+  it('0 / null は -', () => {
+    expect(formatSize(null)).toBe('-')
+    expect(formatSize(0)).toBe('-')
+  })
+  it('B / KB / MB', () => {
+    expect(formatSize(512)).toBe('512 B')
+    expect(formatSize(2048)).toBe('2.0 KB')
+    expect(formatSize(3 * 1024 * 1024)).toBe('3.0 MB')
+  })
+})
+
+describe('formatDate', () => {
+  it('null は -', () => {
+    expect(formatDate(null)).toBe('-')
+  })
+  it('ISO 文字列をローカル整形 (年が含まれる)', () => {
+    const out = formatDate('2026-05-08T14:51:00Z')
+    expect(out).not.toBe('-')
+    expect(out).toContain('2026')
+  })
+})


### PR DESCRIPTION
## 概要

#69 の **stage 1 (frontend dedupe + 部品化)** を実装。ダッシュボード一覧 (`index.vue`) とメール詳細 (`emails/[id].vue`) で別々に持っていた表示ロジックを集約する。

issue が推奨する 2 段階アプローチ (「まず wrap → 後段でスタイル統一」) のうち、**backend 改修なしで frontend だけで完結できる範囲**を本 PR で実施する。

## 変更点

### 1. 共有ヘルパ `app/utils/documentBadges.ts` (新規)
`extractionBadge` / `distributionBadge` / `redactionBadge` / `deliveryStatusLabel` / `formatSize` / `formatDate` を single-source 化。`DocumentCardData` 型もここで定義。

### 2. `app/components/DocumentCard.vue` (新規)
ダッシュボードカードを部品化:
- title / summary / 送信者・日時 + redaction/extraction/distribution の 3 バッジ
- アクション (redact / 非表示 / 削除 等) は呼び出し元固有なので `#actions` slot に委譲
- カード本体クリックの遷移先は `to` prop
- **バッジは値が無いと描画しない**ので、rich フィールドが揃わない呼び出し元 (= メール詳細、backend レスポンス拡張待ち) でも壊れない設計

### 3. `index.vue`
インラインのカード markup + ローカル badge 関数 (約 70 行) を `<DocumentCard>` + 共有ヘルパに置換。#70 で追加した 非表示/削除/redact アクションは `#actions` slot 内に維持 (ハンドラ・state は index.vue に残すので低リスク)。

### 4. `emails/[id].vue`
ローカルの `formatSize` / `formatDate` / `deliveryStatusLabel` を共有ヘルパ import に置換。

## テスト / 検証

- `tests/utils/documentBadges.test.ts` 追加 → 全関数の全分岐を網羅
- `app/utils/**` の **coverage 100% を維持** (vitest 115 pass)
- `npx nuxt build` で 3 つの SFC がコンパイル成功することを確認

## stage 2 (本 PR スコープ外、#69 に残す)

メール詳細カードの DocumentCard **完全採用** (rich 表示への視覚統一 + 配信履歴テーブルを slot 化) は、`GET /notify/emails/{id}` のレスポンスに `extracted_title` / `extracted_summary` / `redaction_status` / `redactions_applied` を含める **rust-alc-api 側の拡張**が前提。これは別 repo・別 issue で先行させる必要があるため本 PR では未対応。本 PR で部品と共有ヘルパの土台ができたので、backend 拡張後は emails 側を `<DocumentCard>` に差し替えるだけで済む。

Refs #69

---
_Generated by [Claude Code](https://claude.ai/code/session_018dUHPkdEV4dqJZqKgemo2E)_