### PR TITLE
feat(documents): 一覧タイトルを配車手配票形式に (Refs #68)

### DIFF
--- a/app/components/DocumentCard.vue
+++ b/app/components/DocumentCard.vue
@@ -3,6 +3,7 @@ import {
   extractionBadge,
   distributionBadge,
   redactionBadge,
+  buildLogisticsTitle,
   type BadgeView,
   type DocumentCardData,
 } from '~/utils/documentBadges'
@@ -29,8 +30,14 @@ const props = withDefaults(
   { to: null, dimmed: false },
 )
 
+// 配車手配票の logistics が抽出済みなら「積込日時 積込県ー降し日時 降し県　輸送品名」
+// を優先。無ければ従来どおり extracted_title || file_name にフォールバック (Refs #68)。
 const title = computed(
-  () => props.doc.extracted_title || props.doc.file_name || 'Untitled',
+  () =>
+    buildLogisticsTitle(props.doc) ||
+    props.doc.extracted_title ||
+    props.doc.file_name ||
+    'Untitled',
 )
 const subtitle = computed(
   () => props.doc.extracted_summary || props.doc.source_subject || '',

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getHiddenIds, hideDocument, unhideDocument } from '~/utils/hiddenDocuments'
+import type { LogisticsFields } from '~/utils/documentBadges'
 
 const { apiFetch } = useApi()
 const { onUpdate: onRedactUpdate } = useRedactionWatch()
@@ -9,6 +10,9 @@ interface NotifyDocument {
   file_name: string | null
   extracted_title: string | null
   extracted_summary: string | null
+  // 一覧 API (SELECT *) が返す抽出結果。logistics があれば DocumentCard が
+  // 「積込日時 積込県ー降し日時 降し県　輸送品名」タイトルを組み立てる (Refs #68)。
+  extracted_data: { logistics?: LogisticsFields | null } | Record<string, unknown> | null
   source_sender: string | null
   source_subject: string | null
   extraction_status: string

--- a/app/utils/documentBadges.ts
+++ b/app/utils/documentBadges.ts
@@ -26,6 +26,9 @@ export interface DocumentCardData extends RedactionBadgeInput {
   created_at: string
   extraction_status?: string
   distribution_status?: string
+  // 配車手配票タイトル組み立て (Refs #68)。一覧 API は extracted_data を
+  // SELECT * でそのまま返すので、ここから logistics を取り出してタイトル化する。
+  extracted_data?: { logistics?: LogisticsFields | null } | Record<string, unknown> | null
 }
 
 export function extractionBadge(status: string): BadgeView {
@@ -112,4 +115,100 @@ export function formatDate(s: string | null): string {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
+
+// ── 配車手配票タイトル組み立て (Refs #68) ───────────────────────────────
+//
+// rust-alc-api の extract.rs が抽出した logistics (extracted_data.logistics)
+// から「積込日時 積込県ー降し日時 降し県　輸送品名」形式のタイトルを組み立てる。
+// backend に専用の県 / 品名フィールドは無いので、県は積地 / 降地の住所文字列
+// から切り出す。輸送品名 (cargo_name) は backend が将来返したら拾う graceful
+// 実装。logistics が無い / 何も組み立てられない時は null を返し、呼び出し側で
+// extracted_title || file_name にフォールバックさせる。
+
+/** タイトル組み立てに使う logistics フィールド (extract.rs の LogisticsFields サブセット)。 */
+export interface LogisticsFields {
+  loading_place?: string | null
+  loading_place_address?: string | null
+  unloading_place?: string | null
+  unloading_place_address?: string | null
+  loading_at?: string | null
+  unloading_at?: string | null
+  /** backend 未対応 (将来 extract.rs が返したら拾う)。 */
+  cargo_name?: string | null
+  [key: string]: unknown
+}
+
+const PREFECTURES = [
+  '北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県',
+  '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県',
+  '新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県', '岐阜県',
+  '静岡県', '愛知県', '三重県', '滋賀県', '京都府', '大阪府', '兵庫県',
+  '奈良県', '和歌山県', '鳥取県', '島根県', '岡山県', '広島県', '山口県',
+  '徳島県', '香川県', '愛媛県', '高知県', '福岡県', '佐賀県', '長崎県',
+  '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県',
+]
+
+/**
+ * 住所 / 地名文字列から最初に現れる都道府県を切り出す。見つからなければ null。
+ * 複数候補があれば最も前方に出るものを採用 (「〒861 熊本県…」のような prefix
+ * ノイズや、住所に他県が含まれるケースに強くする)。
+ */
+export function extractPrefecture(place?: string | null): string | null {
+  if (!place) return null
+  let best: { pref: string; idx: number } | null = null
+  for (const pref of PREFECTURES) {
+    const idx = place.indexOf(pref)
+    if (idx >= 0 && (best === null || idx < best.idx)) {
+      best = { pref, idx }
+    }
+  }
+  return best?.pref ?? null
+}
+
+/**
+ * 日時文字列を「MM/DD HH:mm」相当に整形する。ISO 8601 っぽければ圧縮し、
+ * Gemini が「11/10 08:00」等の自由文で返した場合はそのまま (trim のみ)。
+ */
+function formatLogisticsTime(s?: string | null): string {
+  if (!s) return ''
+  const t = s.trim()
+  if (/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(t)) {
+    const d = new Date(t)
+    if (!Number.isNaN(d.getTime())) {
+      return d.toLocaleString('ja-JP', {
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    }
+  }
+  return t
+}
+
+/** doc.extracted_data.logistics を安全に取り出す (型が緩いレスポンスに耐える)。 */
+function readLogistics(doc: DocumentCardData): LogisticsFields | null {
+  const data = doc.extracted_data
+  if (!data || typeof data !== 'object') return null
+  const l = (data as { logistics?: unknown }).logistics
+  if (!l || typeof l !== 'object') return null
+  return l as LogisticsFields
+}
+
+/**
+ * 「積込日時 積込県ー降し日時 降し県　輸送品名」形式のタイトルを組み立てる。
+ * 材料が何も無ければ null (呼び出し側で extracted_title 等にフォールバック)。
+ */
+export function buildLogisticsTitle(doc: DocumentCardData): string | null {
+  const l = readLogistics(doc)
+  if (!l) return null
+  const loadPref = extractPrefecture(l.loading_place ?? l.loading_place_address)
+  const unloadPref = extractPrefecture(l.unloading_place ?? l.unloading_place_address)
+  const left = [formatLogisticsTime(l.loading_at), loadPref].filter(Boolean).join(' ')
+  const right = [formatLogisticsTime(l.unloading_at), unloadPref].filter(Boolean).join(' ')
+  const route = [left, right].filter(Boolean).join('ー')
+  const cargo = (l.cargo_name ?? '').trim()
+  const title = [route, cargo].filter(Boolean).join('　')
+  return title || null
 }

--- a/tests/utils/documentBadges.test.ts
+++ b/tests/utils/documentBadges.test.ts
@@ -161,6 +161,15 @@ describe('buildLogisticsTitle', () => {
     expect(title).toContain('愛知県')
     expect(title).toMatch(/^\d{2}\/\d{2}\s\d{2}:\d{2}\s愛知県$/)
   })
+  it('正規表現にマッチするが無効な日付 (月13) はそのまま raw 文字列', () => {
+    const title = buildLogisticsTitle(
+      docWith({
+        loading_at: '2026-13-40T08:00',
+        loading_place: '愛知県名古屋市',
+      }),
+    )
+    expect(title).toBe('2026-13-40T08:00 愛知県')
+  })
   it('cargo_name (backend 未対応) が無くても route だけで組む', () => {
     const title = buildLogisticsTitle(
       docWith({

--- a/tests/utils/documentBadges.test.ts
+++ b/tests/utils/documentBadges.test.ts
@@ -6,7 +6,20 @@ import {
   deliveryStatusLabel,
   formatSize,
   formatDate,
+  extractPrefecture,
+  buildLogisticsTitle,
+  type DocumentCardData,
 } from '../../app/utils/documentBadges'
+
+/** buildLogisticsTitle に渡す最小の DocumentCardData を作る。 */
+function docWith(logistics: Record<string, unknown> | null): DocumentCardData {
+  return {
+    id: 'x',
+    file_name: '3387_001.pdf',
+    created_at: '2026-05-09T00:00:00Z',
+    extracted_data: logistics === null ? null : { logistics },
+  }
+}
 
 describe('extractionBadge', () => {
   it('既知ステータス', () => {
@@ -90,5 +103,88 @@ describe('formatDate', () => {
     const out = formatDate('2026-05-08T14:51:00Z')
     expect(out).not.toBe('-')
     expect(out).toContain('2026')
+  })
+})
+
+describe('extractPrefecture', () => {
+  it('先頭の都道府県を切り出す', () => {
+    expect(extractPrefecture('熊本県八代市…')).toBe('熊本県')
+    expect(extractPrefecture('東京都千代田区')).toBe('東京都')
+    expect(extractPrefecture('京都府京都市')).toBe('京都府')
+    expect(extractPrefecture('北海道札幌市')).toBe('北海道')
+  })
+  it('prefix ノイズがあっても拾う', () => {
+    expect(extractPrefecture('〒861-0000 熊本県八代市')).toBe('熊本県')
+  })
+  it('複数県を含む場合は最も前方を採用', () => {
+    expect(extractPrefecture('大阪府経由 東京都行き')).toBe('大阪府')
+  })
+  it('該当なし / 空 / null は null', () => {
+    expect(extractPrefecture('どこか不明な場所')).toBeNull()
+    expect(extractPrefecture('')).toBeNull()
+    expect(extractPrefecture(null)).toBeNull()
+    expect(extractPrefecture(undefined)).toBeNull()
+  })
+})
+
+describe('buildLogisticsTitle', () => {
+  it('日時 + 県ー日時 + 県　品名 を組み立てる', () => {
+    const title = buildLogisticsTitle(
+      docWith({
+        loading_at: '11/10 08:00',
+        loading_place: '北海道札幌市…',
+        unloading_at: '11/11 14:00',
+        unloading_place: '東京都港区…',
+        cargo_name: '冷凍食品',
+      }),
+    )
+    expect(title).toBe('11/10 08:00 北海道ー11/11 14:00 東京都　冷凍食品')
+  })
+  it('住所フィールド (place が無くても address) から県を拾う', () => {
+    const title = buildLogisticsTitle(
+      docWith({
+        loading_at: '8:00',
+        loading_place_address: '〒861 熊本県八代市',
+        unloading_place_address: '大阪府大阪市',
+      }),
+    )
+    expect(title).toBe('8:00 熊本県ー大阪府')
+  })
+  it('ISO 8601 の日時は MM/DD HH:mm に圧縮', () => {
+    const title = buildLogisticsTitle(
+      docWith({
+        loading_at: '2026-11-10T08:00:00',
+        loading_place: '愛知県名古屋市',
+      }),
+    )
+    // ローカルタイムゾーン依存を避けるため県と区切りの存在だけ確認
+    expect(title).toContain('愛知県')
+    expect(title).toMatch(/^\d{2}\/\d{2}\s\d{2}:\d{2}\s愛知県$/)
+  })
+  it('cargo_name (backend 未対応) が無くても route だけで組む', () => {
+    const title = buildLogisticsTitle(
+      docWith({
+        loading_at: '08:00',
+        loading_place: '福岡県',
+        unloading_at: '18:00',
+        unloading_place: '広島県',
+      }),
+    )
+    expect(title).toBe('08:00 福岡県ー18:00 広島県')
+  })
+  it('logistics が空 / 県も日時も拾えなければ null', () => {
+    expect(buildLogisticsTitle(docWith({}))).toBeNull()
+    expect(buildLogisticsTitle(docWith({ notes: 'メモのみ' }))).toBeNull()
+  })
+  it('extracted_data が無い / logistics キーが無いと null', () => {
+    expect(buildLogisticsTitle(docWith(null))).toBeNull()
+    expect(
+      buildLogisticsTitle({
+        id: 'x',
+        file_name: 'a.pdf',
+        created_at: '2026-05-09T00:00:00Z',
+        extracted_data: { summary: 'no logistics' },
+      }),
+    ).toBeNull()
   })
 })


### PR DESCRIPTION
## 概要

ドキュメント一覧カードのタイトルを、配車手配票の中身がひと目で分かる
**「積込日時 積込県ー降し日時 降し県　輸送品名」** 形式に置き換える (Refs #68)。

これまでは `extracted_title || file_name` だったため、`extracted_title` が
空のときファイル名 (`3387_001.pdf` 等) がそのまま出て一覧から内容を判別
できなかった。

例: `11/10 08:00 北海道ー11/11 14:00 東京都　冷凍食品`

## 実装

backend 調査の結果、一覧 API `GET /notify/documents` は `SELECT * FROM
notify_documents` でそのまま `extracted_data` を返しており、`extract.rs` が
抽出した `extracted_data.logistics` も含まれている。よって **backend 変更は
不要** で、frontend で logistics を読んでタイトルを組み立てるだけで対応できる。

- `app/utils/documentBadges.ts` に純粋関数を追加:
  - `buildLogisticsTitle(doc)` — logistics からタイトル組み立て。材料が無ければ
    `null` を返し、呼び出し側で `extracted_title || file_name` にフォールバック
  - `extractPrefecture(place)` — 住所/地名文字列から都道府県を切り出す
    (backend に専用の県フィールドが無いため)。prefix ノイズや複数県混在に強い
  - 日時は ISO 8601 なら `MM/DD HH:mm` に圧縮、Gemini 自由文 (`11/10 08:00`) は
    そのまま
- `app/components/DocumentCard.vue` の `title` を `buildLogisticsTitle` 優先に変更
- `app/pages/index.vue` の `NotifyDocument` に `extracted_data` を追加
  (型のみ。API は既に返している)

## #68 との差分 (残課題)

issue が議論していた `cargo_name`(輸送品名) と `loading/unloading_prefecture`(県)
の **backend フィールド追加は本 PR には含まない**。現状:

- **県**: frontend で住所文字列から切り出して表示 (`extractPrefecture`)
- **輸送品名**: backend に `cargo_name` フィールドが無いため現状は省略。将来
  `extract.rs` が `cargo_name` を返したら `buildLogisticsTitle` が自動で拾う
  graceful 実装にしてある

backend 側で県/品名を正規フィールド化したくなったら別 PR で対応する。

## テスト

`tests/utils/documentBadges.test.ts` に 14 ケース追加 (`extractPrefecture` /
`buildLogisticsTitle`)。全 136 テスト green (`vitest run`)、`app/` 配下の
typecheck エラー 0 件。

Refs #68

https://claude.ai/code/session_01ELcPDvD5gWcbdGiJiQpcSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELcPDvD5gWcbdGiJiQpcSY)_