### PR TITLE
feat(documents): 抽出が固まった時に再抽出導線を出す (Refs #66)

### DIFF
--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -2,6 +2,7 @@
 import { useAuth } from '@ippoan/auth-client'
 import VuePdfEmbed from 'vue-pdf-embed'
 import { fetchPdfBytes } from '~/utils/preview-fetch'
+import { isExtractionStuck } from '~/utils/documentBadges'
 
 const route = useRoute()
 const { apiFetch } = useApi()
@@ -47,6 +48,9 @@ interface NotifyDocument {
   redactions_applied: number | null
   redaction_error: string | null
   created_at: string
+  // 状態が最後に書き換わった時刻。extraction が pending/processing のまま
+  // この時刻から一定時間動かなければ「抽出が固まっている」と判定する (Refs #66)。
+  updated_at?: string | null
 }
 
 interface Delivery {
@@ -165,6 +169,28 @@ const isExtractInProgress = computed(() => {
   const s = document.value?.extraction_status
   return s === 'pending' || s === 'processing'
 })
+
+// 抽出が「固まった」と見なすまでの猶予 (Refs #66)。
+// backend の extract は fire-and-forget の tokio::spawn で、Cloud Run の CPU
+// throttling 等で background が静かに死ぬと pending のまま永久に止まる。
+// updated_at からこの時間動かなければ stuck とみなして再抽出導線を出す。
+const EXTRACT_STUCK_AFTER_MS = 3 * 60 * 1000
+
+// 経過時間を再評価させるための tick。polling 中は document.value の差し替えで
+// computed が再評価されるが、polling が止まった場合や同一値が返り続ける場合に
+// 備えて 30 秒ごとに現在時刻を更新する。
+const nowTick = ref(Date.now())
+let stuckTicker: ReturnType<typeof setInterval> | null = null
+
+// 抽出が処理中表示のまま固まっているか (純粋ロジックは documentBadges に集約)。
+const isExtractStuck = computed(() =>
+  isExtractionStuck(
+    document.value?.extraction_status,
+    document.value?.updated_at,
+    nowTick.value,
+    EXTRACT_STUCK_AFTER_MS,
+  ),
+)
 
 // 配信は redact 完了 / skipped (PDF以外) のみ許可。
 // backend (distribute.rs) でも 400 ブロックされるが、UI 側でもボタンを disable する。
@@ -337,8 +363,14 @@ async function recomputeExtract() {
   recomputingExtract.value = true
   try {
     await apiFetch(`/notify/documents/${document.value.id}/extract-recompute`, { method: 'POST' })
-    // 即座に pending に倒して polling 開始 (バック側は async)
-    if (document.value) document.value.extraction_status = 'pending'
+    // 即座に pending に倒して polling 開始 (バック側は async)。
+    // updated_at も now に倒して stuck タイマーをリセット (再キック直後に
+    // 「固まっている」表示が出ないように)。
+    if (document.value) {
+      document.value.extraction_status = 'pending'
+      document.value.updated_at = new Date().toISOString()
+    }
+    nowTick.value = Date.now()
     schedulePollIfProcessing()
   } catch (e: any) {
     alert(`運送情報の抽出やり直しに失敗: ${e.message ?? e}`)
@@ -454,6 +486,10 @@ onMounted(async () => {
       loadPreview()
     }
   }
+  // stuck 判定の経過時間を定期再評価 (Refs #66)。
+  stuckTicker = setInterval(() => {
+    nowTick.value = Date.now()
+  }, 30_000)
 })
 
 // notify-realtime-bus からの terminal status push を受信したら現在のドキュメントを patch。
@@ -478,6 +514,10 @@ onUnmounted(() => {
   if (pollTimer) {
     clearTimeout(pollTimer)
     pollTimer = null
+  }
+  if (stuckTicker) {
+    clearInterval(stuckTicker)
+    stuckTicker = null
   }
   // 進行中の preview fetch があれば abort。leak した Worker 通信を絶つ。
   previewAbort?.abort()
@@ -650,7 +690,24 @@ onUnmounted(() => {
 
         <!-- extract 処理中: 配車 PDF だが logistics がまだ書かれていない -->
         <div v-else-if="isPdf && isExtractInProgress" class="mt-3 pt-3 border-t">
-          <div class="text-sm text-gray-500">
+          <!-- 一定時間 進まない = 抽出ジョブが固まっている (Refs #66)。
+               再抽出導線を目立たせる。 -->
+          <div v-if="isExtractStuck"
+               class="text-xs bg-amber-50 border border-amber-200 text-amber-800 px-3 py-2 rounded">
+            <div class="flex items-center justify-between gap-2">
+              <span class="font-medium">⚠️ 抽出が完了しません</span>
+              <button @click="recomputeExtract"
+                      :disabled="recomputingExtract"
+                      class="text-xs bg-amber-100 hover:bg-amber-200 border border-amber-300 px-3 py-1 rounded disabled:opacity-50">
+                {{ recomputingExtract ? '再抽出中…' : '🔄 再抽出' }}
+              </button>
+            </div>
+            <p class="mt-1">
+              数分待っても運送情報が出ない場合、抽出ジョブが途中で止まっている
+              可能性があります。「🔄 再抽出」でやり直してください。
+            </p>
+          </div>
+          <div v-else class="text-sm text-gray-500">
             🔍 運送情報を抽出中…
           </div>
         </div>

--- a/app/utils/documentBadges.ts
+++ b/app/utils/documentBadges.ts
@@ -117,6 +117,34 @@ export function formatDate(s: string | null): string {
   })
 }
 
+// ── 抽出 stuck 判定 (Refs #66) ──────────────────────────────────────────
+//
+// backend の extract は fire-and-forget の tokio::spawn で、Cloud Run の CPU
+// throttling 等で background が静かに死ぬと extraction_status が pending の
+// まま永久に止まる。updated_at から一定時間動かなければ stuck とみなし、
+// 詳細画面で再抽出導線を目立たせる判定に使う。updated_at が無い (旧 API) /
+// 不正な値なら判定材料が無いので false にフォールバックする。
+
+/**
+ * 抽出が「処理中表示のまま固まっている」か。
+ * - extraction_status が pending / processing 以外なら常に false
+ * - updated_at が無い / パースできなければ false
+ * - now - updated_at が threshold を超えたら true
+ */
+export function isExtractionStuck(
+  extractionStatus: string | undefined | null,
+  updatedAt: string | null | undefined,
+  nowMs: number,
+  thresholdMs: number,
+): boolean {
+  const inProgress = extractionStatus === 'pending' || extractionStatus === 'processing'
+  if (!inProgress) return false
+  if (!updatedAt) return false
+  const t = new Date(updatedAt).getTime()
+  if (Number.isNaN(t)) return false
+  return nowMs - t > thresholdMs
+}
+
 // ── 配車手配票タイトル組み立て (Refs #68) ───────────────────────────────
 //
 // rust-alc-api の extract.rs が抽出した logistics (extracted_data.logistics)

--- a/tests/utils/documentBadges.test.ts
+++ b/tests/utils/documentBadges.test.ts
@@ -8,6 +8,7 @@ import {
   formatDate,
   extractPrefecture,
   buildLogisticsTitle,
+  isExtractionStuck,
   type DocumentCardData,
 } from '../../app/utils/documentBadges'
 
@@ -124,6 +125,38 @@ describe('extractPrefecture', () => {
     expect(extractPrefecture('')).toBeNull()
     expect(extractPrefecture(null)).toBeNull()
     expect(extractPrefecture(undefined)).toBeNull()
+  })
+})
+
+describe('isExtractionStuck', () => {
+  const NOW = Date.parse('2026-05-09T12:00:00Z')
+  const THRESHOLD = 3 * 60 * 1000 // 3 分
+
+  it('pending で updated_at が threshold より古ければ stuck', () => {
+    const old = new Date(NOW - 5 * 60 * 1000).toISOString()
+    expect(isExtractionStuck('pending', old, NOW, THRESHOLD)).toBe(true)
+  })
+  it('processing でも同様に判定する', () => {
+    const old = new Date(NOW - 10 * 60 * 1000).toISOString()
+    expect(isExtractionStuck('processing', old, NOW, THRESHOLD)).toBe(true)
+  })
+  it('threshold 以内なら stuck ではない', () => {
+    const recent = new Date(NOW - 60 * 1000).toISOString()
+    expect(isExtractionStuck('pending', recent, NOW, THRESHOLD)).toBe(false)
+  })
+  it('completed / failed など処理中でなければ常に false', () => {
+    const old = new Date(NOW - 60 * 60 * 1000).toISOString()
+    expect(isExtractionStuck('completed', old, NOW, THRESHOLD)).toBe(false)
+    expect(isExtractionStuck('failed', old, NOW, THRESHOLD)).toBe(false)
+    expect(isExtractionStuck(undefined, old, NOW, THRESHOLD)).toBe(false)
+    expect(isExtractionStuck(null, old, NOW, THRESHOLD)).toBe(false)
+  })
+  it('updated_at が無い (旧 API) と判定不能で false', () => {
+    expect(isExtractionStuck('pending', null, NOW, THRESHOLD)).toBe(false)
+    expect(isExtractionStuck('pending', undefined, NOW, THRESHOLD)).toBe(false)
+  })
+  it('updated_at がパースできない文字列なら false', () => {
+    expect(isExtractionStuck('pending', 'not-a-date', NOW, THRESHOLD)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## 概要

ドキュメント詳細画面で運送情報の抽出 (extract) が **「🔍 運送情報を抽出中…」
のまま永久に固まる** 問題 (#66) の **frontend 側の stuck 検知導線** を追加する。

## root cause

backend (`rust-alc-api`) の extract は fire-and-forget の `tokio::spawn`
(`spawn_extract_document`) で動いており、Cloud Run の CPU throttling 等で
background task が静かに死ぬと `extraction_status` が `pending` のまま
止まる。timeout も起動時 recovery も無いため自動復旧せず、polling は
永遠にステータス変化を見られない。

## 本 PR (frontend) の対応

stuck を検知して **手動復旧 (再抽出) の導線を目立たせる**:

- `documentBadges.ts` に純粋関数 `isExtractionStuck(status, updatedAt, now,
  thresholdMs)` を追加。`pending`/`processing` かつ `updated_at` から閾値
  (3分) 動かなければ stuck と判定。`updated_at` が無い旧 API / 不正値は
  `false` にフォールバック
- `documents/[id].vue`:
  - `NotifyDocument` に `updated_at` を追加 (一覧と同じく `SELECT *` で既に返る)
  - stuck 時は「⚠️ 抽出が完了しません」+「🔄 再抽出」ボタンを amber で強調
  - 経過時間を 30 秒ごとに再評価する ticker を `onMounted`/`onUnmounted` で管理
  - 再抽出クリック時に `updated_at` を楽観的に now へ倒し、再キック直後に
    stuck 表示が出ないようリセット
- ユニットテスト 6 ケース追加 (`isExtractionStuck` の全分岐)

## スコープ外 (別 PR: rust-alc-api)

issue が求めた **backend 側の根治** はこの repo では対応できないため別 PR:

- extract ジョブの timeout / リトライ上限 → 超過で `failed` に遷移
- 起動時に長時間 `processing`/`pending` のレコードを recovery
- `extract-recompute` で `extraction_status` を `pending` にリセット + `updated_at` bump

frontend の stuck 検知は backend 変更が landing する前でも単独で機能する
(`updated_at` が無ければ従来どおり「抽出中…」表示にフォールバックするだけ)。

## テスト

`vitest run --coverage`: 全 143 テスト green、`app/utils` /
`app/composables` カバレッジ 100% (threshold 維持)。`app/` 配下 typecheck
エラー 0 件。

Refs #66

https://claude.ai/code/session_01ELcPDvD5gWcbdGiJiQpcSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELcPDvD5gWcbdGiJiQpcSY)_