### PR TITLE
refactor(realtime-bus): HS256 JWT 検証を @ippoan/mcp-cf-workers/auth 消費に置換

### DIFF
--- a/.github/workflows/realtime-bus-deploy.yml
+++ b/.github/workflows/realtime-bus-deploy.yml
@@ -29,6 +29,8 @@ jobs:
       cache_dependency_path: 'workers/realtime-bus/package-lock.json'
       install_command: 'npm install'
       typecheck_command: 'npx tsc --noEmit'
+      # @ippoan/mcp-cf-workers (GitHub Packages) の install に必要
+      npm_scope: '@ippoan'
       # vitest はまだ追加してない (Phase 2.5 の最小スコープ)。
       # E2E は wscat + curl で staging 確認 → 後追いで unit (Phase 2.6)。
       test_command: 'echo "no tests yet"'

--- a/workers/realtime-bus/.npmrc
+++ b/workers/realtime-bus/.npmrc
@@ -1,0 +1,7 @@
+# @ippoan scope (@ippoan/mcp-cf-workers) は GitHub Packages 公開。
+# GitHub Packages の npm registry は public パッケージでも read に token が要る
+# 仕様なので、CI は frontend-ci.yml が npm_scope:'@ippoan' で setup-node を
+# 構成し NODE_AUTH_TOKEN=GITHUB_TOKEN を注入する。ローカルは PAT (read:packages)
+# を NODE_AUTH_TOKEN に入れるか、clone を file: link する。
+@ippoan:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/workers/realtime-bus/.npmrc
+++ b/workers/realtime-bus/.npmrc
@@ -5,3 +5,9 @@
 # を NODE_AUTH_TOKEN に入れるか、clone を file: link する。
 @ippoan:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+
+# @ippoan/mcp-cf-workers は durable path 用に `agents` を optional peer として
+# 宣言している。`agents` は vite >=6 を peer 要求するが、本 worker の vitest 2.x は
+# vite 5 系。本 worker は ./auth export のみ消費し durable path を使わないので、
+# この optional peer 衝突は無視してよい (cdp-relay と同じ対処)。
+legacy-peer-deps=true

--- a/workers/realtime-bus/package.json
+++ b/workers/realtime-bus/package.json
@@ -10,6 +10,9 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@ippoan/mcp-cf-workers": "dev"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260101.0",
     "@vitest/coverage-v8": "^2.1.0",

--- a/workers/realtime-bus/src/jwt.ts
+++ b/workers/realtime-bus/src/jwt.ts
@@ -1,80 +1,45 @@
 // HS256 JWT 検証 (rust-alc-api と同じ JWT_SECRET で署名された tokens を検証)
 //
-// rust-alc-api の JWT クレーム (`crates/alc-core/src/auth_jwt.rs`):
+// rust-alc-api の JWT クレーム (`crates/alc-auth-jwt`):
 //   { sub, email, name, tenant_id (uuid), role, iat, exp }
 // ここでは tenant_id を取り出して DO ルーティング名前空間に使う。
+//
+// 検証本体は `@ippoan/mcp-cf-workers` の `./auth` export (`verifyHs256Jwt`) を
+// 消費する (Refs ippoan/mcp-cf-workers#46 — 自前 Web Crypto コピーの解消)。
+// 本 worker の契約 (null-on-fail / tenant_id 必須 / skew なし) は wrapper で維持。
+import {
+  verifyHs256Jwt,
+  Hs256JwtError,
+  type Hs256BaseClaims,
+} from "@ippoan/mcp-cf-workers/auth";
 
-export interface JwtClaims {
+export interface JwtClaims extends Hs256BaseClaims {
   sub: string;
   tenant_id: string;
-  exp: number;
   // 他フィールドはこの Worker では使わない
-  [key: string]: unknown;
-}
-
-const enc = new TextEncoder();
-
-function base64UrlDecode(s: string): Uint8Array {
-  // base64url → base64 に変換 (`-`/`_` を `+`/`/` に置換、padding 追加)
-  const pad = "=".repeat((4 - (s.length % 4)) % 4);
-  const b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
-  const bin = atob(b64);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
-  return diff === 0;
 }
 
 /**
  * HS256 JWT を検証して claims を返す。失敗時は null。
  *
- * - 署名検証 (HMAC-SHA256, constant-time 比較)
- * - exp 期限切れチェック (現時刻 ≤ exp)
+ * - 署名検証 (HMAC-SHA256, constant-time 比較) + alg=HS256 pin
+ * - exp 期限切れチェック (skew なし — 旧ローカル実装と同じ)
  * - tenant_id 必須
  */
 export async function verifyJwt(
   token: string,
   secret: string,
 ): Promise<JwtClaims | null> {
-  const parts = token.split(".");
-  if (parts.length !== 3) return null;
-  const [headerB64, payloadB64, sigB64] = parts;
-
-  // 1. 署名検証
-  const key = await crypto.subtle.importKey(
-    "raw",
-    enc.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const expected = new Uint8Array(
-    await crypto.subtle.sign("HMAC", key, enc.encode(`${headerB64}.${payloadB64}`)),
-  );
-  const provided = base64UrlDecode(sigB64);
-  if (!constantTimeEqual(expected, provided)) return null;
-
-  // 2. payload parse
-  let claims: JwtClaims;
   try {
-    const json = new TextDecoder().decode(base64UrlDecode(payloadB64));
-    claims = JSON.parse(json) as JwtClaims;
+    return await verifyHs256Jwt<JwtClaims>(token, secret, {
+      clockToleranceSec: 0,
+      validateClaims: (c) => {
+        if (typeof c.tenant_id !== "string" || !c.tenant_id) {
+          throw new Hs256JwtError("tenant_id");
+        }
+      },
+    });
   } catch {
     return null;
   }
-
-  // 3. 期限チェック (exp は UNIX 秒)
-  const now = Math.floor(Date.now() / 1000);
-  if (typeof claims.exp !== "number" || claims.exp < now) return null;
-
-  // 4. tenant_id 必須
-  if (typeof claims.tenant_id !== "string" || !claims.tenant_id) return null;
-
-  return claims;
 }

--- a/workers/realtime-bus/src/jwt.ts
+++ b/workers/realtime-bus/src/jwt.ts
@@ -7,11 +7,13 @@
 // 検証本体は `@ippoan/mcp-cf-workers` の `./auth` export (`verifyHs256Jwt`) を
 // 消費する (Refs ippoan/mcp-cf-workers#46 — 自前 Web Crypto コピーの解消)。
 // 本 worker の契約 (null-on-fail / tenant_id 必須 / skew なし) は wrapper で維持。
+// barrel (./auth) は jose 依存の cf-access / mcp-jwt を re-export するため、
+// jose を持たない本 worker は subpath export を直接 import する。
 import {
   verifyHs256Jwt,
   Hs256JwtError,
   type Hs256BaseClaims,
-} from "@ippoan/mcp-cf-workers/auth";
+} from "@ippoan/mcp-cf-workers/auth/hs256-jwt";
 
 export interface JwtClaims extends Hs256BaseClaims {
   sub: string;


### PR DESCRIPTION
## 概要

Refs ippoan/mcp-cf-workers#46 (consumer 移行 4/5)

realtime-bus worker の自前 HS256 verifier を `@ippoan/mcp-cf-workers@dev` の `./auth` export 消費に置換する。

## 変更内容

- **`workers/realtime-bus/src/jwt.ts`**: `verifyJwt` を `verifyHs256Jwt` の薄い wrapper に。null-on-fail / tenant_id 必須 / skew なし (`clockToleranceSec: 0`) の契約は維持
  - 挙動差 1 点 (strictness 向上): **alg=HS256 pin が新たに入る** — 旧実装は header.alg を検証していなかった (署名は HMAC 再計算なので実害はなかったが、lib 版が正)
- **配線**: realtime-bus の package.json に `@ippoan/mcp-cf-workers@dev` を追加、`.npmrc` + realtime-bus-deploy.yml に `npm_scope: '@ippoan'` を追加 (`packages: read` は宣言済みだった)。lockfile は install_command が `npm install` のため CI 側で解決される

## 検証

- `npm run typecheck` green (realtime-bus は unit test 未整備の repo — Phase 2.6 で後追い予定のまま)

https://claude.ai/code/session_01SfZxUUha4yj2Po3LWmLVDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfZxUUha4yj2Po3LWmLVDA)_