### PR TITLE
fix(auth): recoverFromCookie を呼んでログインループを解消

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -2,7 +2,7 @@
 import { useAuth, AuthToolbar } from '@ippoan/auth-client'
 
 const route = useRoute()
-const { isAuthenticated, loadFromStorage, consumeFragment, redirectToLogin } = useAuth()
+const { isAuthenticated, loadFromStorage, consumeFragment, recoverFromCookie, redirectToLogin } = useAuth()
 const runtimeConfig = useRuntimeConfig()
 const { apiFetch } = useApi()
 
@@ -54,7 +54,13 @@ async function selectTenant(tenantId: string) {
 }
 
 onMounted(() => {
-  consumeFragment()
+  // OAuth リダイレクト直後は URL fragment (#token=...) を消費。fragment が無い
+  // (= notify.ippoan.org への通常遷移) 場合は、auth-worker が *.ippoan.org に配る
+  // logi_auth_token cookie (Domain=.ippoan.org) から復元する。recoverFromCookie を
+  // 呼ばないと cookie 配布ログインを拾えず「ログインしてください」でループする。
+  if (!consumeFragment()) {
+    recoverFromCookie()
+  }
   loadFromStorage()
 
   // エラー・テナント選択パラメータをチェック


### PR DESCRIPTION
## 障害

`notify.ippoan.org` で「ログインしてください」→ Google/LINE でログインしても認証されず、ログイン画面に戻る**ループ**。

## 原因

`app/app.vue` の `onMounted` が `consumeFragment()` + `loadFromStorage()` しか呼んでおらず、**`recoverFromCookie()` を呼んでいなかった**。

現行 auth-worker のログインは *.ippoan.org 向けに `logi_auth_token` cookie（`Domain=.ippoan.org`）を配る cross-subdomain 方式が基本。callback が URL fragment（`#token=...`）を返さない経路では `consumeFragment()` が空振りし、cookie に届いた token を拾えず `isAuthenticated` が false のまま → ログイン画面に戻る。

carins / alc-app など他の *.ippoan.org consumer は `recoverFromCookie()` を呼んでおり、notify だけ欠けていた（`use_auth_client_dev: true` で dev 版 auth-client を使うので関数は利用可能）。

## 修正

```ts
if (!consumeFragment()) {
  recoverFromCookie()   // *.ippoan.org cookie から復元
}
loadFromStorage()
```

- fragment 経路（OAuth 直後に `#token=` が付く場合）は従来どおり `consumeFragment()` が処理
- fragment が無い通常遷移 / cookie-only callback は `recoverFromCookie()` が `logi_auth_token` cookie から復元
- `selectTenant`（LINE 複数テナント）経路は変更なし

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxbZrRe2gsZuoDGAAo53Nv)_