### PR TITLE
ci: 各 unit deploy で report_worker_name を渡し monorepo Release Wave flip を有効化

### DIFF
--- a/.github/workflows/email-worker-deploy.yml
+++ b/.github/workflows/email-worker-deploy.yml
@@ -26,6 +26,9 @@ jobs:
     with:
       project_type: 'worker'
       working_directory: 'workers/email-receiver'
+      # monorepo unit worker。pending/traffic-report を per-worker
+      # (`traffic::<repo>::notify-email-receiver`) で記録 (Refs ippoan/ci-dashboard#427)。
+      report_worker_name: notify-email-receiver
       cache_dependency_path: 'workers/email-receiver/package-lock.json'
       install_command: 'npm ci'
       typecheck_command: 'npx tsc --noEmit'

--- a/.github/workflows/realtime-bus-deploy.yml
+++ b/.github/workflows/realtime-bus-deploy.yml
@@ -26,6 +26,9 @@ jobs:
     with:
       project_type: 'worker'
       working_directory: 'workers/realtime-bus'
+      # monorepo unit worker。pending/traffic-report を per-worker
+      # (`traffic::<repo>::notify-realtime-bus`) で記録 (Refs ippoan/ci-dashboard#427)。
+      report_worker_name: notify-realtime-bus
       cache_dependency_path: 'workers/realtime-bus/package-lock.json'
       install_command: 'npm install'
       typecheck_command: 'npx tsc --noEmit'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
       install_command: 'npm install'
       npm_scope: '@ippoan'
       use_auth_client_dev: true
+      # monorepo 3 unit の app worker。deploy の pending/traffic-report を
+      # per-worker (`traffic::<repo>::nuxt-notify`) で記録させ、Release Wave の
+      # Pending releases / flip を unit 単位で機能させる (Refs ippoan/ci-dashboard#427)。
+      report_worker_name: nuxt-notify
       has_integration: true
       integration_test_command: 'npx vitest run tests/integration/'
       integration_env: 'API_BASE_URL=http://localhost:18080'


### PR DESCRIPTION
## 目的

monorepo Release Wave 対応（ci-dashboard#428 / ci-workflows#143/#144/#145、すべて merged）の **最後の配線**。notify の 3 unit deploy が `report_worker_name` に各 CF script 名を渡し、deploy 時の pending-release / traffic-report を **per-worker**（`traffic::<repo>::<worker>`）で記録させる。

これまでは `traffic::ippoan/nuxt-notify` の repo 単位キーで 3 worker が衝突し、flip dispatch にも worker 名が無く handler が `wrangler versions deploy --name ""` → `scripts//deployments` 404 で失敗していた。

## 変更

| workflow | unit | `report_worker_name` |
|---|---|---|
| `test.yml` (app) | nuxt-notify | `nuxt-notify` |
| `email-worker-deploy.yml` | email-receiver | `notify-email-receiver` |
| `realtime-bus-deploy.yml` | realtime-bus | `notify-realtime-bus` |

値は各 `wrangler.toml`/`.jsonc` の `name` および `release-wave-targets.yaml` の `monorepo_units` と一致（flip の `--name` と traffic key を揃える）。

## 効果

merge 後、各 unit の release deploy（no-traffic upload）が per-worker pending/traffic record を作り、ci-dashboard `/release-wave` の **Pending releases に 3 unit が個別に並び、unit ごとに「Flip to 100%」できる**ようになる。これで notify の Release Wave flip が end-to-end で機能する。

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxbZrRe2gsZuoDGAAo53Nv)_