### PR TITLE
feat: 認証付き REST を /api/proxy 経由に移行 (#434 step 2)

### DIFF
--- a/.claude/skills/nuxt-notify-map/SKILL.md
+++ b/.claude/skills/nuxt-notify-map/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nuxt-notify-map
 generated-from: nuxt-notify:eba745f247d411f8e2a1146109ddc086d81da853
-paths: [app/, workers/]
+paths: [app/, server/, workers/]
 description: ippoan/nuxt-notify (文書配信・メール受信・墨消し通知 PWA、Nuxt 4 + Cloudflare Workers) の構造ナビゲーション。frontend pages / 2 つの補助 Worker (email-receiver / realtime-bus DO) / 墨消し WebSocket 通知の配置と prod/staging 構成・gotcha を 1 枚にまとめる。トリガー:「nuxt-notify」「notify.ippoan.org」「メール受信」「email-receiver」「realtime-bus」「RedactBus」「墨消し」「redaction」「LINE WORKS 配信」「公文書配信」「v/[token]」等。
 ---
 
@@ -23,6 +23,7 @@ realtime-bus Worker の WebSocket で push される。
 | **components** | `DistributeModal.vue`, `FolderWatcher.vue`, `UploadButton.vue` | 配信モーダル / フォルダ監視 / アップロード |
 | **composables** | `useApi.ts`, `useFilePicker.ts`, `useFolderWatcher.ts`, `useRedactionWatch.ts` | API / ファイル選択 / フォルダ監視 / 墨消し WS 購読 |
 | **utils** | `app/utils/{folderWatchDb,preview-fetch}.ts` | フォルダ監視 IndexedDB / プレビュー取得 |
+| **server route** | `server/api/proxy/[...path].ts` | 認証付き REST proxy。`@ippoan/auth-client/server` の `createIdentityProxyHandler` で introspect 検証 → X-Tenant-ID + X-User-* 注入 → rust-alc-api `/api/*` 転送 (#434 step 2)。AUTH_WORKER service binding + INTERNAL_SHARED_SECRET 必須 |
 | **Worker: email-receiver** | `workers/email-receiver/src/index.ts` | Cloudflare Email Routing 受信 → host で prod/staging 振り分け → backend ingest に POST (PostalMime で parse) |
 | **Worker: realtime-bus** | `workers/realtime-bus/src/{index,redact-bus,jwt}.ts` | 墨消し完了の DO fan-out。`POST /broadcast` (backend push) / `GET /subscribe` (browser WS)。`RedactBus` DO は hibernation 対応 |
 
@@ -39,6 +40,16 @@ realtime-bus Worker の WebSocket で push される。
 - **frontend は runtime secret を持たない** が、ci-workflows の secret-verify gate を pass させるため wrangler.jsonc に `"secrets": {"required": []}` を**明示 declare** (Refs ippoan/ci-workflows#50)。空でも消さない。
 - **email-receiver は 1 Worker で prod/staging 両受け**。host (notify.ippoan.org / notify-staging…) で `pickRoute` がエンドポイント+secret を選ぶ。`MAX_TOTAL_BYTES=25MB` / `MAX_ATTACHMENTS=20`。
 - **realtime-bus は no-op 許容**。frontend の `realtimeBusUrl` 未設定なら `useRedactionWatch` は no-op (既存 polling が UI 更新を担う)。WS subprotocol は `"bearer,<jwt>"`、broadcast は `X-Broadcast-Secret` で検証。
+- **認証付き JSON API は `/api/proxy/*` 経由** (#434 step 2)。`useApi().apiFetch` /
+  preview / download は相対 `/api/proxy/...` を叩き、proxy が introspect で tenant を
+  注入する。client は Bearer token だけ載せ X-Tenant-ID は手動付与しない。
+- **公開 viewer `v/[token]` は proxy を通さない**。認証不要で `apiBase` を直叩きする
+  (`/api/notify/v/{token}` / `/file`)。proxy に通すと introspect 401 になるので壊さない。
+- **multipart upload (`useApi().uploadFetch`) は proxy 非経由** で `apiBase` 直叩きのまま。
+  `createIdentityProxyHandler` は body を JSON.stringify するため multipart を壊す
+  (carins は base64 JSON で送る別契約)。multipart の proxy 化は要追加検討。
+- **OAuth redirect (`/api/auth/line/redirect`、app.vue / settings.vue)** も `apiBase` 直叩き。
+  introspect 前の redirect 経路なので proxy 化しない。
 - README.md は Nuxt boilerplate。
 
 ## CCoW / CI から見た立ち位置

--- a/.claude/skills/nuxt-notify-map/SKILL.md
+++ b/.claude/skills/nuxt-notify-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuxt-notify-map
-generated-from: nuxt-notify:eba745f247d411f8e2a1146109ddc086d81da853
+generated-from: nuxt-notify:ee3c79b5af895a2fe776ce33d9083105e7553198
 paths: [app/, server/, workers/]
 description: ippoan/nuxt-notify (文書配信・メール受信・墨消し通知 PWA、Nuxt 4 + Cloudflare Workers) の構造ナビゲーション。frontend pages / 2 つの補助 Worker (email-receiver / realtime-bus DO) / 墨消し WebSocket 通知の配置と prod/staging 構成・gotcha を 1 枚にまとめる。トリガー:「nuxt-notify」「notify.ippoan.org」「メール受信」「email-receiver」「realtime-bus」「RedactBus」「墨消し」「redaction」「LINE WORKS 配信」「公文書配信」「v/[token]」等。
 ---

--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -1,5 +1,18 @@
 import { useAuth } from '@ippoan/auth-client'
 
+// #434 step 2: 認証付き JSON REST 呼び出し (apiFetch) は server route /api/proxy/*
+// 経由にする。proxy が auth-worker introspect で JWT を検証し、検証済み identity を
+// X-Tenant-ID + X-User-* として rust-alc-api に注入する。client は introspect の
+// ため Bearer token (cookie でも可) だけ載せ、X-Tenant-ID は手動付与しない
+// (proxy が検証済み tenant を注入するため、client 自称 tenant は不要・無視される)。
+//
+// path は backend の /api/<path> に対応する。proxy は pathPrefix=/api/ を付けるので
+// client は /api/proxy/<path> を叩く (例: /notify/recipients → /api/proxy/notify/recipients)。
+//
+// uploadFetch (multipart/form-data) は **proxy を通さない** で apiBase 直叩きのまま。
+// createIdentityProxyHandler は body を JSON.stringify するため multipart を壊す
+// (carins は base64 JSON で送る別契約だが nuxt-notify backend は multipart 前提)。
+// multipart の proxy 化は要追加検討 (PR 説明参照)。
 export function useApi() {
   const config = useRuntimeConfig()
   const apiBase = config.public.apiBase as string
@@ -18,10 +31,11 @@ export function useApi() {
   async function apiFetch<T>(path: string, options: { method?: string; body?: string } = {}): Promise<T> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...authHeaders(),
     }
+    // proxy が introspect 用に token を読む。X-Tenant-ID は手動付与しない。
+    if (token.value) headers['Authorization'] = `Bearer ${token.value}`
 
-    return await $fetch<T>(`${apiBase}/api${path}`, {
+    return await $fetch<T>(`/api/proxy${path}`, {
       method: (options.method ?? 'GET') as 'GET' | 'POST' | 'PUT' | 'DELETE',
       body: options.body,
       headers,
@@ -30,6 +44,7 @@ export function useApi() {
 
   // multipart/form-data 用。Content-Type は $fetch (ofetch) が
   // boundary 込みで自動設定するので明示しない。
+  // proxy 非経由 (上記コメント参照): apiBase 直叩き + 旧 authHeaders 維持。
   async function uploadFetch<T>(path: string, formData: FormData): Promise<T> {
     return await $fetch<T>(`${apiBase}/api${path}`, {
       method: 'POST',

--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -6,7 +6,7 @@ import { isExtractionStuck } from '~/utils/documentBadges'
 
 const route = useRoute()
 const { apiFetch } = useApi()
-const { token, orgId } = useAuth()
+const { token } = useAuth()
 const { onUpdate: onRedactUpdate } = useRedactionWatch()
 
 const documentId = computed(() => String(route.params.id))
@@ -279,21 +279,17 @@ async function loadPreview() {
   previewError.value = ''
   pdfPages.value = 0
   try {
-    const config = useRuntimeConfig()
-    const apiBase = config.public.apiBase as string
+    // #434 step 2: /api/proxy/* 経由 (introspect で tenant 注入)。X-Tenant-ID は
+    // 手動付与しない。binary レスポンスは proxy が透過する。
     const headers: Record<string, string> = {}
-    if (token.value) {
-      headers.Authorization = `Bearer ${token.value}`
-    } else if (orgId.value) {
-      headers['X-Tenant-ID'] = orgId.value
-    }
+    if (token.value) headers.Authorization = `Bearer ${token.value}`
     const qs = previewMode.value === 'original' ? '?original=true' : ''
     // 認証付きで preview を取得。Content-Type で PDF / 画像を分岐:
     //   - application/pdf → VuePdfEmbed (PDF.js)
     //   - image/jpeg, image/png, etc. → <img> (rust-alc-api PR #327 以降の
     //     redacted は JPEG 1 枚で配信される)
     const res = await fetch(
-      `${apiBase}/api/notify/documents/${document.value.id}/preview${qs}`,
+      `/api/proxy/notify/documents/${document.value.id}/preview${qs}`,
       { headers, signal: ctrl.signal },
     )
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -387,15 +383,10 @@ function switchPreview(mode: 'redacted' | 'original') {
 async function downloadDoc() {
   if (!document.value) return
   try {
-    const config = useRuntimeConfig()
-    const apiBase = config.public.apiBase as string
+    // #434 step 2: /api/proxy/* 経由 (introspect で tenant 注入)。
     const headers: Record<string, string> = {}
-    if (token.value) {
-      headers.Authorization = `Bearer ${token.value}`
-    } else if (orgId.value) {
-      headers['X-Tenant-ID'] = orgId.value
-    }
-    const res = await fetch(`${apiBase}/api/notify/documents/${document.value.id}/download`, { headers })
+    if (token.value) headers.Authorization = `Bearer ${token.value}`
+    const res = await fetch(`/api/proxy/notify/documents/${document.value.id}/download`, { headers })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const blob = await res.blob()
     const url = URL.createObjectURL(blob)

--- a/app/pages/emails/[id].vue
+++ b/app/pages/emails/[id].vue
@@ -5,7 +5,7 @@ import { formatSize, formatDate, deliveryStatusLabel } from '~/utils/documentBad
 const route = useRoute()
 const router = useRouter()
 const { apiFetch } = useApi()
-const { token, orgId } = useAuth()
+const { token } = useAuth()
 
 const messageId = computed(() => String(route.params.id))
 
@@ -78,15 +78,10 @@ async function loadDeliveries(doc: EmailDocument) {
 
 async function downloadDoc(doc: EmailDocument) {
   try {
-    const config = useRuntimeConfig()
-    const apiBase = config.public.apiBase as string
+    // #434 step 2: /api/proxy/* 経由 (introspect で tenant 注入)。
     const headers: Record<string, string> = {}
-    if (token.value) {
-      headers.Authorization = `Bearer ${token.value}`
-    } else if (orgId.value) {
-      headers['X-Tenant-ID'] = orgId.value
-    }
-    const res = await fetch(`${apiBase}/api/notify/documents/${doc.id}/download`, { headers })
+    if (token.value) headers.Authorization = `Bearer ${token.value}`
+    const res = await fetch(`/api/proxy/notify/documents/${doc.id}/download`, { headers })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const blob = await res.blob()
     const url = URL.createObjectURL(blob)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,7 +9,16 @@ export default defineNuxtConfig({
     preset: 'cloudflare_module',
   },
 
+  // @ippoan/auth-client/server (createIdentityProxyHandler) を Nitro が transpile
+  // できるよう指定。.vue / .mjs ソースをそのまま ship するため必要。
+  build: {
+    transpile: ['@ippoan/auth-client'],
+  },
+
   runtimeConfig: {
+    // server-only: /api/proxy が転送する rust-alc-api backend URL。
+    // wrangler.jsonc の NUXT_ALC_API_URL から注入される。
+    alcApiUrl: process.env.NUXT_ALC_API_URL || 'https://alc-api.ippoan.org',
     public: {
       apiBase: 'http://localhost:8080',
       authWorkerUrl: 'https://auth.ippoan.org',

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "^0.2.28",
+    "@ippoan/auth-client": "dev",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.4.2",
     "vue": "^3.5.31",

--- a/server/api/proxy/[...path].ts
+++ b/server/api/proxy/[...path].ts
@@ -1,0 +1,60 @@
+/**
+ * REST API プロキシ
+ * /api/proxy/* → rust-alc-api の /api/* に転送
+ *
+ * #434 step 2: introspect 検証 → X-Tenant-ID + X-User-ID/Email/Role 注入を
+ * @ippoan/auth-client/server の createIdentityProxyHandler に集約。旧
+ * client 側 X-Tenant-ID 手動付与 (useApi.authHeaders) を置換する。
+ * rust-alc-api は #441 で JWT 検証を撤去し注入 identity を信頼する dumb backend
+ * になったため、X-User-* を載せないと require_tenant_header が AuthUser を
+ * 復元できず AuthUser 必須 handler が 500 になる。createIdentityProxyHandler は
+ * introspect 結果から X-User-* も載せてこれを解消する。
+ *
+ * introspect は AUTH_WORKER service binding (worker-to-worker, in-process) で
+ * 叩くので外部 req を増やさない。INTERNAL_SHARED_SECRET は Secrets Store
+ * binding (.get()) のため route 側で resolve してから渡す。
+ *
+ * 注意: 公開 viewer (/v/[token]) は認証不要で rust-alc-api を直叩きするため
+ * この proxy は通さない (introspect 401 になる)。viewer は apiBase 直叩きのまま。
+ */
+import type { H3Event } from 'h3'
+import { createIdentityProxyHandler } from '@ippoan/auth-client/server'
+
+function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+/** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
+async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}
+
+export default defineEventHandler(async (event) => {
+  const env = cfEnv(event)
+  const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+  if (!sharedSecret) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です',
+    })
+  }
+  const authWorkerUrl =
+    typeof env.NUXT_PUBLIC_AUTH_WORKER_URL === 'string' && env.NUXT_PUBLIC_AUTH_WORKER_URL
+      ? env.NUXT_PUBLIC_AUTH_WORKER_URL
+      : 'https://auth.ippoan.org'
+  const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+
+  const proxy = createIdentityProxyHandler({
+    backendUrl: (e) =>
+      (useRuntimeConfig(e).alcApiUrl as string) || 'https://alc-api.ippoan.org',
+    authWorkerUrl,
+    sharedSecret,
+    // AUTH_WORKER service binding 経由で introspect (worker-to-worker, in-process)。
+    introspectFetch: authWorker ? () => authWorker.fetch.bind(authWorker) : undefined,
+  })
+  return proxy(event)
+})

--- a/tests/composables/useApi.test.ts
+++ b/tests/composables/useApi.test.ts
@@ -27,12 +27,14 @@ describe('useApi', () => {
     mockOrgId.value = null
   })
 
-  it('GET request with no auth', async () => {
+  // apiFetch は #434 step 2 で /api/proxy/* 経由になった。proxy が introspect で
+  // tenant を注入するため、client は X-Tenant-ID を手動付与しない。
+  it('GET request with no auth (proxy 経由、X-Tenant-ID なし)', async () => {
     mockFetch.mockResolvedValue([{ id: '1' }])
     const { apiFetch } = useApi()
     const result = await apiFetch('/notify/recipients')
 
-    expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/api/notify/recipients', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/proxy/notify/recipients', {
       method: 'GET',
       body: undefined,
       headers: { 'Content-Type': 'application/json' },
@@ -46,14 +48,14 @@ describe('useApi', () => {
     const body = JSON.stringify({ name: 'Test' })
     await apiFetch('/notify/recipients', { method: 'POST', body })
 
-    expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/api/notify/recipients', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/proxy/notify/recipients', {
       method: 'POST',
       body,
       headers: { 'Content-Type': 'application/json' },
     })
   })
 
-  it('adds Authorization header when JWT token exists', async () => {
+  it('adds Authorization header when JWT token exists (X-Tenant-ID は注入しない)', async () => {
     mockToken.value = 'jwt-test-token'
     mockOrgId.value = 'tenant-123'
     mockFetch.mockResolvedValue([])
@@ -61,7 +63,7 @@ describe('useApi', () => {
     const { apiFetch } = useApi()
     await apiFetch('/notify/documents')
 
-    expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/api/notify/documents', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/proxy/notify/documents', {
       method: 'GET',
       body: undefined,
       headers: {
@@ -71,7 +73,7 @@ describe('useApi', () => {
     })
   })
 
-  it('adds X-Tenant-ID when no JWT but orgId exists', async () => {
+  it('orgId のみでも X-Tenant-ID は付けない (proxy が tenant を注入)', async () => {
     mockToken.value = null
     mockOrgId.value = '11111111-1111-1111-1111-111111111111'
     mockFetch.mockResolvedValue([])
@@ -79,13 +81,10 @@ describe('useApi', () => {
     const { apiFetch } = useApi()
     await apiFetch('/notify/documents')
 
-    expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/api/notify/documents', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/proxy/notify/documents', {
       method: 'GET',
       body: undefined,
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-ID': '11111111-1111-1111-1111-111111111111',
-      },
+      headers: { 'Content-Type': 'application/json' },
     })
   })
 
@@ -94,7 +93,7 @@ describe('useApi', () => {
     const { apiFetch } = useApi()
     await apiFetch('/notify/recipients/abc', { method: 'DELETE' })
 
-    expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/api/notify/recipients/abc', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/proxy/notify/recipients/abc', {
       method: 'DELETE',
       body: undefined,
       headers: { 'Content-Type': 'application/json' },
@@ -107,14 +106,15 @@ describe('useApi', () => {
     const body = JSON.stringify({ enabled: false })
     await apiFetch('/notify/recipients/abc', { method: 'PUT', body })
 
-    expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/api/notify/recipients/abc', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/proxy/notify/recipients/abc', {
       method: 'PUT',
       body,
       headers: { 'Content-Type': 'application/json' },
     })
   })
 
-  describe('uploadFetch', () => {
+  // uploadFetch は multipart のため proxy を通さず apiBase 直叩きのまま (旧挙動維持)。
+  describe('uploadFetch (proxy 非経由、apiBase 直叩き)', () => {
     it('POSTs FormData without Content-Type (boundary set by ofetch)', async () => {
       mockFetch.mockResolvedValue({ document_ids: ['id-1'], count: 1 })
       const { uploadFetch } = useApi()

--- a/tests/server/proxy.test.ts
+++ b/tests/server/proxy.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// 転送 + introspect 検証 + identity 注入の本体は @ippoan/auth-client/server の
+// createIdentityProxyHandler に集約 (#434 step 2)。挙動テスト (introspect /
+// X-Tenant-ID + X-User-* 注入 / binary・JSON 分類) は lib 側 (auth-worker)。
+// ここでは本 repo の server route の wiring を固定する:
+//   1. INTERNAL_SHARED_SECRET binding を resolve して渡す (未設定は 503)
+//   2. AUTH_WORKER service binding / authWorkerUrl / backendUrl を解決して委譲
+//   3. createIdentityProxyHandler の戻り値で proxy(event) を返す
+
+const { createIdentityProxyHandlerMock, proxyFn, createErrorMock } = vi.hoisted(() => {
+  const proxyFn = vi.fn(() => 'PROXY_RESULT')
+  ;(globalThis as Record<string, unknown>).defineEventHandler = (fn: unknown) => fn
+  const createErrorMock = vi.fn((opts: unknown) => {
+    const err = new Error('createError') as Error & { opts?: unknown }
+    err.opts = opts
+    throw err
+  })
+  ;(globalThis as Record<string, unknown>).createError = createErrorMock
+  return {
+    proxyFn,
+    createIdentityProxyHandlerMock: vi.fn((_opts: unknown) => proxyFn),
+    createErrorMock,
+  }
+})
+vi.mock('@ippoan/auth-client/server', () => ({
+  createIdentityProxyHandler: createIdentityProxyHandlerMock,
+}))
+
+vi.stubGlobal('useRuntimeConfig', () => ({ alcApiUrl: 'https://test-api.example.com' }))
+
+import handler from '../../server/api/proxy/[...path]'
+
+interface ProxyWiring {
+  backendUrl: (event: unknown) => string
+  authWorkerUrl: string
+  sharedSecret: string
+}
+
+const call = (event: unknown) => (handler as unknown as (e: unknown) => Promise<unknown>)(event)
+const eventWith = (env: Record<string, unknown>) => ({ context: { cloudflare: { env } } })
+
+describe('proxy handler wiring (createIdentityProxyHandler, #434)', () => {
+  beforeEach(() => {
+    createIdentityProxyHandlerMock.mockClear()
+    proxyFn.mockClear()
+    createErrorMock.mockClear()
+  })
+
+  it('INTERNAL_SHARED_SECRET があれば委譲し proxy(event) を返す', async () => {
+    const event = eventWith({
+      INTERNAL_SHARED_SECRET: 'secret-x',
+      NUXT_PUBLIC_AUTH_WORKER_URL: 'https://auth-test.example.com',
+      AUTH_WORKER: { fetch: vi.fn() },
+    })
+    const res = await call(event)
+    expect(createIdentityProxyHandlerMock).toHaveBeenCalledTimes(1)
+    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    expect(opts.sharedSecret).toBe('secret-x')
+    expect(opts.authWorkerUrl).toBe('https://auth-test.example.com')
+    expect(proxyFn).toHaveBeenCalledWith(event)
+    expect(res).toBe('PROXY_RESULT')
+  })
+
+  it('INTERNAL_SHARED_SECRET が Secrets Store binding (.get()) でも解決する', async () => {
+    const event = eventWith({
+      INTERNAL_SHARED_SECRET: { get: async () => 'from-store' },
+      AUTH_WORKER: { fetch: vi.fn() },
+    })
+    await call(event)
+    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    expect(opts.sharedSecret).toBe('from-store')
+  })
+
+  it('INTERNAL_SHARED_SECRET 未設定なら 503 で弾く (委譲しない)', async () => {
+    await expect(call(eventWith({}))).rejects.toThrow()
+    expect(createErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 503 }),
+    )
+    expect(createIdentityProxyHandlerMock).not.toHaveBeenCalled()
+  })
+
+  it('NUXT_PUBLIC_AUTH_WORKER_URL 未設定なら本番 auth-worker にフォールバック', async () => {
+    await call(eventWith({ INTERNAL_SHARED_SECRET: 'x' }))
+    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    expect(opts.authWorkerUrl).toBe('https://auth.ippoan.org')
+  })
+
+  it('backendUrl は runtimeConfig.alcApiUrl を解決する', async () => {
+    await call(eventWith({ INTERNAL_SHARED_SECRET: 'x' }))
+    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    expect(opts.backendUrl({})).toBe('https://test-api.example.com')
+  })
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,12 +13,31 @@
 		"enabled": true,
 		"head_sampling_rate": 1
 	},
-	// Nuxt frontend は runtime secret を持たない (config 値は public な NUXT_PUBLIC_*
-	// 環境変数のみ)。ippoan/ci-workflows の secret-verify gate を明示的に pass
-	// させるため、空 list を declare する (Refs ippoan/ci-workflows#50)。
+	// frontend-ci.yml の secret-verify job が secret backup の auditability の
+	// ため明示宣言を要求する。INTERNAL_SHARED_SECRET は Secrets Store binding
+	// として別途宣言するため、ここは引き続き空 list で良い (Refs ippoan/ci-workflows#50)。
 	"secrets": {
 		"required": []
 	},
+	// REST proxy (server/api/proxy/[...path].ts, #434 step 2) 用。
+	// leg A: auth-worker /auth/introspect を service binding (worker-to-worker) で
+	// 叩いて browser JWT を検証する。INTERNAL_SHARED_SECRET は introspect の認証用
+	// (alc-app / carins / dtako-logs と同じ CF Secrets Store entry を物理共有)。
+	// leg B (rust-alc-api への X-Tenant-ID / X-User-* 転送) には proxy 真正性 secret を
+	// 載せない。bare X-Tenant-ID 直叩きは Cloud Run の網層ロックダウンで塞ぐ方針。
+	"services": [
+		{
+			"binding": "AUTH_WORKER",
+			"service": "auth-worker"
+		}
+	],
+	"secrets_store_secrets": [
+		{
+			"binding": "INTERNAL_SHARED_SECRET",
+			"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+			"secret_name": "INTERNAL_SHARED_SECRET"
+		}
+	],
 	"env": {
 		"staging": {
 			"name": "nuxt-notify-staging",
@@ -30,13 +49,32 @@
 			],
 			"vars": {
 				"NUXT_PUBLIC_API_BASE": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
+				// /api/proxy が叩く rust-alc-api backend (server-only, #434 step 2)。
+				"NUXT_ALC_API_URL": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
 				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org",
 				"NUXT_PUBLIC_REALTIME_BUS_URL": "wss://realtime.notify-staging.ippoan.org"
-			}
+			},
+			// named env は top-level binding を継承しないので再宣言する。
+			// staging は auth-worker-staging を叩く。
+			"services": [
+				{
+					"binding": "AUTH_WORKER",
+					"service": "auth-worker-staging"
+				}
+			],
+			"secrets_store_secrets": [
+				{
+					"binding": "INTERNAL_SHARED_SECRET",
+					"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+					"secret_name": "INTERNAL_SHARED_SECRET"
+				}
+			]
 		}
 	},
 	"vars": {
 		"NUXT_PUBLIC_API_BASE": "https://alc-api.ippoan.org",
+		// /api/proxy が叩く rust-alc-api backend (server-only, #434 step 2)。
+		"NUXT_ALC_API_URL": "https://alc-api.ippoan.org",
 		"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth.ippoan.org",
 		"NUXT_PUBLIC_REALTIME_BUS_URL": "wss://realtime.notify.ippoan.org"
 	},


### PR DESCRIPTION
## 概要

rust-alc-api#434 step 2 の consumer 横展開を nuxt-notify に適用。認証付き JSON REST を `@ippoan/auth-client/server` の `createIdentityProxyHandler` 経由 (`/api/proxy/*`) に集約し、client 側の `X-Tenant-ID` 手動付与を撤去する。proxy が auth-worker introspect で JWT を検証し、検証済み identity を `X-Tenant-ID` + `X-User-*` として rust-alc-api に注入する (rust-alc-api#441 で JWT 検証を撤去した dumb backend 対応)。

## 変更点

### 配線
- **`server/api/proxy/[...path].ts` 新設** — carins / dtako-logs と同形。`createIdentityProxyHandler` に `backendUrl` (runtimeConfig.alcApiUrl) / `authWorkerUrl` / `sharedSecret` / `introspectFetch` (AUTH_WORKER service binding) を委譲。`INTERNAL_SHARED_SECRET` は Secrets Store binding (`.get()`) として route 側で resolve、未設定なら 503。
- **`wrangler.jsonc`** — top-level + `env.staging` に `services` (AUTH_WORKER / auth-worker(-staging)) + `secrets_store_secrets` (INTERNAL_SHARED_SECRET、store `bd7bc91a…`) を追加。`NUXT_ALC_API_URL` を prod (`https://alc-api.ippoan.org`) / staging (`https://rust-alc-api-staging-…run.app`) の vars に追加。
- **`nuxt.config.ts`** — `runtimeConfig.alcApiUrl` (server-only) + `build.transpile: ['@ippoan/auth-client']` を追加。
- **`package.json`** — `@ippoan/auth-client` を `dev` に (`createIdentityProxyHandler` は dev dist-tag のみ)。`test.yml` は `use_auth_client_dev: true` 設定済み。

### frontend 移行
- `useApi().apiFetch` を `/api/proxy${path}` (相対) 経由に。client 側 `X-Tenant-ID` 手動付与を撤去 (proxy が検証済み tenant を注入)。Bearer token のみ introspect 用に維持。
- `documents/[id].vue` の preview / download、`emails/[id].vue` の download を `/api/proxy/notify/...` 経由に。`X-Tenant-ID` 手動付与撤去、未使用 `orgId` 削除。
- `tests/server/proxy.test.ts` (wiring) 追加 + `tests/composables/useApi.test.ts` 更新。

## 非移行 (意図的) — 要レビュー

- **`useApi().uploadFetch` (multipart) は proxy 非経由** で `apiBase` 直叩きのまま。`createIdentityProxyHandler` は body を `JSON.stringify` するため multipart を壊す (carins は base64 JSON で送る別契約だが nuxt-notify backend `/notify/documents/upload` は multipart 前提)。**multipart の proxy 化は要追加検討** (base64 JSON 化 or 専用 server route)。
- **公開 viewer `v/[token]` は proxy を通さない** — 認証不要なので `apiBase` 直叩きのまま (proxy に通すと introspect 401)。CLAUDE.md の「viewer を壊さない」方針を維持。
- **OAuth redirect (`/api/auth/line/redirect`、app.vue / settings.vue)** も `apiBase` 直叩き — introspect 前の redirect 経路のため proxy 化しない。

## 検証

- `npx vitest run` (integration 除く): 137 件 pass (proxy.test.ts 5 件 + useApi.test.ts 含む)。
- `nuxi typecheck`: nuxt-notify 自身のファイル (server/app/tests) にエラー 0 (`file:` local copy 由来の auth-client src 警告のみ、CI の実 `@ippoan/auth-client@dev` install では解消)。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bihe6n6P8Pds5grZzR4ga)_