### PR TITLE
chore(deps): @ippoan/auth-client を ^0.2.75 stable に repin (rust-alc-api#434)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "dev",
+    "@ippoan/auth-client": "^0.2.75",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.4.2",
     "vue": "^3.5.31",


### PR DESCRIPTION
## 概要

`@ippoan/auth-client` を `"dev"` → `"^0.2.75"`(stable) に repin（root package.json のみ。`workers/email-receiver` は別 package.json で無関係）。**prod(v\* tag)=stable / staging(PR/main push)=`use_auth_client_dev` の @dev overlay** の二系統運用に揃える。

main(push) で dev overlay が走らず古い dev（[npm/cli#7562](https://github.com/npm/cli/issues/7562)）で typecheck/vitest が赤になっていた問題を解消。

- 本 repin 単体でも main push は stable 0.2.75 で緑化。
- ippoan/auth-worker#305 が merge されると staging が dev overlay に切替。
- `use_auth_client_dev: true` は維持。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bihe6n6P8Pds5grZzR4ga)_