### PR TITLE
feat(proxy): createAuthWorkerProxyHandler (方式B) に切替えて SA key を排除

### DIFF
--- a/.claude/skills/nuxt-notify-map/SKILL.md
+++ b/.claude/skills/nuxt-notify-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuxt-notify-map
-generated-from: nuxt-notify:ee3c79b5af895a2fe776ce33d9083105e7553198
+generated-from: nuxt-notify:498d98203156348e234f9d28f9cf1665469c4cb4
 paths: [app/, server/, workers/]
 description: ippoan/nuxt-notify (文書配信・メール受信・墨消し通知 PWA、Nuxt 4 + Cloudflare Workers) の構造ナビゲーション。frontend pages / 2 つの補助 Worker (email-receiver / realtime-bus DO) / 墨消し WebSocket 通知の配置と prod/staging 構成・gotcha を 1 枚にまとめる。トリガー:「nuxt-notify」「notify.ippoan.org」「メール受信」「email-receiver」「realtime-bus」「RedactBus」「墨消し」「redaction」「LINE WORKS 配信」「公文書配信」「v/[token]」等。
 ---
@@ -23,7 +23,7 @@ realtime-bus Worker の WebSocket で push される。
 | **components** | `DistributeModal.vue`, `FolderWatcher.vue`, `UploadButton.vue` | 配信モーダル / フォルダ監視 / アップロード |
 | **composables** | `useApi.ts`, `useFilePicker.ts`, `useFolderWatcher.ts`, `useRedactionWatch.ts` | API / ファイル選択 / フォルダ監視 / 墨消し WS 購読 |
 | **utils** | `app/utils/{folderWatchDb,preview-fetch}.ts` | フォルダ監視 IndexedDB / プレビュー取得 |
-| **server route** | `server/api/proxy/[...path].ts` | 認証付き REST proxy。`@ippoan/auth-client/server` の `createIdentityProxyHandler` で introspect 検証 → X-Tenant-ID + X-User-* 注入 → rust-alc-api `/api/*` 転送 (#434 step 2)。AUTH_WORKER service binding + INTERNAL_SHARED_SECRET 必須 |
+| **server route** | `server/api/proxy/[...path].ts` | 認証付き REST proxy。`@ippoan/auth-client/server` の `createAuthWorkerProxyHandler` で auth-worker `/alc-proxy/*` に service binding thin-forward (#434 step 3 方式 B)。introspect / ACL / OIDC mint / X-Tenant-ID + X-User-* 注入は auth-worker 側に集約。consumer は X-Alc-Proxy-Secret (=INTERNAL_SHARED_SECRET) + browser JWT のみ。AUTH_WORKER service binding + INTERNAL_SHARED_SECRET 必須 |
 | **Worker: email-receiver** | `workers/email-receiver/src/index.ts` | Cloudflare Email Routing 受信 → host で prod/staging 振り分け → backend ingest に POST (PostalMime で parse) |
 | **Worker: realtime-bus** | `workers/realtime-bus/src/{index,redact-bus,jwt}.ts` | 墨消し完了の DO fan-out。`POST /broadcast` (backend push) / `GET /subscribe` (browser WS)。`RedactBus` DO は hibernation 対応 |
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "^0.2.75",
+    "@ippoan/auth-client": "dev",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.4.2",
     "vue": "^3.5.31",

--- a/server/api/proxy/[...path].ts
+++ b/server/api/proxy/[...path].ts
@@ -1,24 +1,20 @@
 /**
  * REST API プロキシ
- * /api/proxy/* → rust-alc-api の /api/* に転送
+ * /api/proxy/* → auth-worker /alc-proxy/* → rust-alc-api の /api/*
  *
- * #434 step 2: introspect 検証 → X-Tenant-ID + X-User-ID/Email/Role 注入を
- * @ippoan/auth-client/server の createIdentityProxyHandler に集約。旧
- * client 側 X-Tenant-ID 手動付与 (useApi.authHeaders) を置換する。
- * rust-alc-api は #441 で JWT 検証を撤去し注入 identity を信頼する dumb backend
- * になったため、X-User-* を載せないと require_tenant_header が AuthUser を
- * 復元できず AuthUser 必須 handler が 500 になる。createIdentityProxyHandler は
- * introspect 結果から X-User-* も載せてこれを解消する。
- *
- * introspect は AUTH_WORKER service binding (worker-to-worker, in-process) で
- * 叩くので外部 req を増やさない。INTERNAL_SHARED_SECRET は Secrets Store
- * binding (.get()) のため route 側で resolve してから渡す。
+ * #434 step 3 (方式 B): introspect / ACL / OIDC mint / identity 注入を
+ * auth-worker `/alc-proxy/*` に集約し、consumer は createAuthWorkerProxyHandler で
+ * service binding (AUTH_WORKER) に thin-forward するだけ。旧 createIdentityProxyHandler
+ * (方式 A) を置換。consumer は X-Alc-Proxy-Secret (=INTERNAL_SHARED_SECRET、consumer
+ * proof) + X-Alc-Proxy-Origin + browser JWT のみ。auth-worker (#308) が
+ * X-Alc-Proxy-Secret を constant-time 検証してから JWT 検証 + ACL + OIDC mint +
+ * X-Tenant-ID/X-User-* 注入を行う。AUTH_WORKER は方式 B で必須 (未設定は 503)。
  *
  * 注意: 公開 viewer (/v/[token]) は認証不要で rust-alc-api を直叩きするため
- * この proxy は通さない (introspect 401 になる)。viewer は apiBase 直叩きのまま。
+ * この proxy は通さない (viewer は apiBase 直叩きのまま)。
  */
 import type { H3Event } from 'h3'
-import { createIdentityProxyHandler } from '@ippoan/auth-client/server'
+import { createAuthWorkerProxyHandler } from '@ippoan/auth-client/server'
 
 function cfEnv(event: H3Event): Record<string, unknown> {
   return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
@@ -42,19 +38,17 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です',
     })
   }
-  const authWorkerUrl =
-    typeof env.NUXT_PUBLIC_AUTH_WORKER_URL === 'string' && env.NUXT_PUBLIC_AUTH_WORKER_URL
-      ? env.NUXT_PUBLIC_AUTH_WORKER_URL
-      : 'https://auth.ippoan.org'
   const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+  if (!authWorker) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'AUTH_WORKER service binding が未設定です',
+    })
+  }
 
-  const proxy = createIdentityProxyHandler({
-    backendUrl: (e) =>
-      (useRuntimeConfig(e).alcApiUrl as string) || 'https://alc-api.ippoan.org',
-    authWorkerUrl,
+  const proxy = createAuthWorkerProxyHandler({
     sharedSecret,
-    // AUTH_WORKER service binding 経由で introspect (worker-to-worker, in-process)。
-    introspectFetch: authWorker ? () => authWorker.fetch.bind(authWorker) : undefined,
+    authWorkerFetch: () => authWorker.fetch.bind(authWorker),
   })
   return proxy(event)
 })

--- a/tests/server/proxy.test.ts
+++ b/tests/server/proxy.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// 転送 + introspect 検証 + identity 注入の本体は @ippoan/auth-client/server の
-// createIdentityProxyHandler に集約 (#434 step 2)。挙動テスト (introspect /
-// X-Tenant-ID + X-User-* 注入 / binary・JSON 分類) は lib 側 (auth-worker)。
-// ここでは本 repo の server route の wiring を固定する:
+// 転送 + introspect + ACL + OIDC mint + identity 注入の本体は auth-worker
+// `/alc-proxy/*` に集約 (#434 step 3 方式 B)。consumer の server route は
+// createAuthWorkerProxyHandler で service binding (AUTH_WORKER) に thin-forward
+// するだけ。ここでは本 repo の server route の wiring を固定する:
 //   1. INTERNAL_SHARED_SECRET binding を resolve して渡す (未設定は 503)
-//   2. AUTH_WORKER service binding / authWorkerUrl / backendUrl を解決して委譲
-//   3. createIdentityProxyHandler の戻り値で proxy(event) を返す
+//   2. AUTH_WORKER service binding を解決して authWorkerFetch を渡す (未設定は 503)
+//   3. createAuthWorkerProxyHandler の戻り値で proxy(event) を返す
 
-const { createIdentityProxyHandlerMock, proxyFn, createErrorMock } = vi.hoisted(() => {
+const { createAuthWorkerProxyHandlerMock, proxyFn, createErrorMock } = vi.hoisted(() => {
   const proxyFn = vi.fn(() => 'PROXY_RESULT')
   ;(globalThis as Record<string, unknown>).defineEventHandler = (fn: unknown) => fn
   const createErrorMock = vi.fn((opts: unknown) => {
@@ -19,45 +19,46 @@ const { createIdentityProxyHandlerMock, proxyFn, createErrorMock } = vi.hoisted(
   ;(globalThis as Record<string, unknown>).createError = createErrorMock
   return {
     proxyFn,
-    createIdentityProxyHandlerMock: vi.fn((_opts: unknown) => proxyFn),
+    createAuthWorkerProxyHandlerMock: vi.fn((_opts: unknown) => proxyFn),
     createErrorMock,
   }
 })
 vi.mock('@ippoan/auth-client/server', () => ({
-  createIdentityProxyHandler: createIdentityProxyHandlerMock,
+  createAuthWorkerProxyHandler: createAuthWorkerProxyHandlerMock,
 }))
-
-vi.stubGlobal('useRuntimeConfig', () => ({ alcApiUrl: 'https://test-api.example.com' }))
 
 import handler from '../../server/api/proxy/[...path]'
 
 interface ProxyWiring {
-  backendUrl: (event: unknown) => string
-  authWorkerUrl: string
   sharedSecret: string
+  authWorkerFetch: () => typeof fetch
 }
 
 const call = (event: unknown) => (handler as unknown as (e: unknown) => Promise<unknown>)(event)
 const eventWith = (env: Record<string, unknown>) => ({ context: { cloudflare: { env } } })
 
-describe('proxy handler wiring (createIdentityProxyHandler, #434)', () => {
+describe('proxy handler wiring (createAuthWorkerProxyHandler, #434 方式 B)', () => {
   beforeEach(() => {
-    createIdentityProxyHandlerMock.mockClear()
+    createAuthWorkerProxyHandlerMock.mockClear()
     proxyFn.mockClear()
     createErrorMock.mockClear()
   })
 
-  it('INTERNAL_SHARED_SECRET があれば委譲し proxy(event) を返す', async () => {
+  it('INTERNAL_SHARED_SECRET + AUTH_WORKER があれば委譲し proxy(event) を返す', async () => {
+    const authFetch = vi.fn()
     const event = eventWith({
       INTERNAL_SHARED_SECRET: 'secret-x',
-      NUXT_PUBLIC_AUTH_WORKER_URL: 'https://auth-test.example.com',
-      AUTH_WORKER: { fetch: vi.fn() },
+      AUTH_WORKER: { fetch: authFetch },
     })
     const res = await call(event)
-    expect(createIdentityProxyHandlerMock).toHaveBeenCalledTimes(1)
-    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    expect(createAuthWorkerProxyHandlerMock).toHaveBeenCalledTimes(1)
+    const opts = createAuthWorkerProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
     expect(opts.sharedSecret).toBe('secret-x')
-    expect(opts.authWorkerUrl).toBe('https://auth-test.example.com')
+    // authWorkerFetch() は AUTH_WORKER.fetch (binding 済み) を返す
+    expect(typeof opts.authWorkerFetch).toBe('function')
+    const bound = opts.authWorkerFetch()
+    bound('https://alc-proxy.internal/alc-proxy/api/x')
+    expect(authFetch).toHaveBeenCalled()
     expect(proxyFn).toHaveBeenCalledWith(event)
     expect(res).toBe('PROXY_RESULT')
   })
@@ -68,27 +69,23 @@ describe('proxy handler wiring (createIdentityProxyHandler, #434)', () => {
       AUTH_WORKER: { fetch: vi.fn() },
     })
     await call(event)
-    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    const opts = createAuthWorkerProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
     expect(opts.sharedSecret).toBe('from-store')
   })
 
   it('INTERNAL_SHARED_SECRET 未設定なら 503 で弾く (委譲しない)', async () => {
-    await expect(call(eventWith({}))).rejects.toThrow()
+    await expect(call(eventWith({ AUTH_WORKER: { fetch: vi.fn() } }))).rejects.toThrow()
     expect(createErrorMock).toHaveBeenCalledWith(
       expect.objectContaining({ statusCode: 503 }),
     )
-    expect(createIdentityProxyHandlerMock).not.toHaveBeenCalled()
+    expect(createAuthWorkerProxyHandlerMock).not.toHaveBeenCalled()
   })
 
-  it('NUXT_PUBLIC_AUTH_WORKER_URL 未設定なら本番 auth-worker にフォールバック', async () => {
-    await call(eventWith({ INTERNAL_SHARED_SECRET: 'x' }))
-    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
-    expect(opts.authWorkerUrl).toBe('https://auth.ippoan.org')
-  })
-
-  it('backendUrl は runtimeConfig.alcApiUrl を解決する', async () => {
-    await call(eventWith({ INTERNAL_SHARED_SECRET: 'x' }))
-    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
-    expect(opts.backendUrl({})).toBe('https://test-api.example.com')
+  it('AUTH_WORKER service binding 未設定なら 503 で弾く (委譲しない)', async () => {
+    await expect(call(eventWith({ INTERNAL_SHARED_SECRET: 'x' }))).rejects.toThrow()
+    expect(createErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 503 }),
+    )
+    expect(createAuthWorkerProxyHandlerMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 概要

REST proxy route を方式 A (`createIdentityProxyHandler`) → 方式 B (`createAuthWorkerProxyHandler`) に切替える (Refs ippoan/rust-alc-api#434 step 3 consumer 横展開)。

introspect / ACL / OIDC mint / identity 注入 (X-Tenant-ID + X-User-*) を auth-worker `/alc-proxy/*` に集約し、consumer は service binding (`AUTH_WORKER`) に thin-forward するだけになる。これにより consumer 側から SA key / OIDC mint / introspect を排除する。

## 変更点

- `server/api/proxy/[...path].ts`: `createAuthWorkerProxyHandler` に切替。`sharedSecret` (INTERNAL_SHARED_SECRET、Secrets Store binding `.get()` 対応) + `authWorkerFetch` (AUTH_WORKER service binding) を渡す。AUTH_WORKER 未設定は 503。`pathPrefix` は指定せず default `/api/` のまま (現行と同じ)。
- `tests/server/proxy.test.ts`: mock を `createAuthWorkerProxyHandler` に変更。sharedSecret / authWorkerFetch の wiring、INTERNAL_SHARED_SECRET 未設定→503、AUTH_WORKER 未設定→503 を assert。
- `package.json`: `@ippoan/auth-client` を `dev` dist-tag に (`createAuthWorkerProxyHandler` は dev のみ)。test.yml は既に `use_auth_client_dev: true`。
- `.claude/skills/nuxt-notify-map/SKILL.md`: proxy 説明を方式 B に更新 + `generated-from` bump。

## 維持事項

公開 viewer (`/v/[token]`) は認証不要で rust-alc-api を直叩きするためこの proxy を通さない。viewer 経路は触っていない (proxy route のみ変更)。

## 検証

- `npx vitest run tests/server/proxy.test.ts` → 4 passed (file: link で auth-client を解決して確認、lockfile は commit せず)

Refs ippoan/rust-alc-api#434

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoQNRaoDQ1NqMB8bHPMzjK)_