### PR TITLE
fix(deps): @ippoan/auth-client を stable ^0.2.78 に pin + npm install (Refs ippoan/rust-alc-api#434)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "dev",
+    "@ippoan/auth-client": "^0.2.78",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.4.2",
     "vue": "^3.5.31",


### PR DESCRIPTION
## 不具合 / 原因

prod tag release が `Cannot find module '@ippoan/auth-client/server'` で失敗。`use-auth-client-dev` action(main 済み)は **非 tag で `@dev` overlay / `v*` tag(prod)で package.json の stable pin を使用**。consumer が `"dev"` 固定だったため prod tag に stable pin が無く失敗。

## 修正

- `package.json` の `@ippoan/auth-client` を `"dev"` → `"^0.2.78"`。
- `test.yml` の `install_command` を `npm ci` → `npm install`。notify は npm ci で lockfile 厳密一致が要るため、pin 変更で mismatch する。他 6 consumer と同じ `npm install` に揃える(install 時に lockfile を解決し直す)。

staging(PR/main)は action が `@dev` を overlay、prod(`v*` tag)はこの stable pin を使う。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoQNRaoDQ1NqMB8bHPMzjK)_