### PR TITLE
feat: LINE Login を auth-worker (/oauth/line/*) に向ける (Refs rust-alc-api#434 Phase 4)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -4,16 +4,16 @@ import { useAuth, AuthToolbar } from '@ippoan/auth-client'
 const route = useRoute()
 const { isAuthenticated, loadFromStorage, consumeFragment, recoverFromCookie, redirectToLogin } = useAuth()
 const runtimeConfig = useRuntimeConfig()
-const { apiFetch } = useApi()
 
 // `/v/...` は配信受信者向けの公開 viewer (ログイン不要)。
 // header / 認証ゲートを丸ごとスキップして NuxtPage だけを描画する。
 const isPublicView = computed(() => route.path.startsWith('/v/'))
 
+// #434 Phase 4: LINE Login は rust ではなく auth-worker (/oauth/line/*) を向く。
+const authWorkerUrl = runtimeConfig.public.authWorkerUrl as string
 const lineLoginUrl = computed(() => {
-  const apiBase = runtimeConfig.public.apiBase as string
   const redirectUri = encodeURIComponent(window.location.origin + '/?lw_callback=1')
-  return `${apiBase}/api/auth/line/redirect?redirect_uri=${redirectUri}`
+  return `${authWorkerUrl}/oauth/line/redirect?redirect_uri=${redirectUri}`
 })
 
 // エラーメッセージ (LINE Login 失敗時)
@@ -29,15 +29,17 @@ const selectingTenant = ref(false)
 async function selectTenant(tenantId: string) {
   selectingTenant.value = true
   try {
-    const res = await apiFetch<{ access_token: string; refresh_token: string; expires_in: number }>(
-      '/auth/line/select-tenant',
+    // select-tenant は pre-login (JWT 無し) なので /api/proxy 経由ではなく
+    // auth-worker の public route を直接叩く (#434 Phase 4)。
+    const res = await $fetch<{ access_token: string; refresh_token: string; expires_in: number }>(
+      `${authWorkerUrl}/oauth/line/select-tenant`,
       {
         method: 'POST',
-        body: JSON.stringify({
+        body: {
           line_user_id: lineUserId.value,
           line_name: lineName.value,
           tenant_id: tenantId,
-        }),
+        },
       },
     )
     // JWT をストレージに保存してリロード

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -35,10 +35,12 @@ const qrCodeUrl = computed(() => {
   return `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(friendAddUrl.value)}`
 })
 
+const authWorkerUrl = runtimeConfig.public.authWorkerUrl as string
 const inviteLoginUrl = computed(() => {
   if (!orgId.value) return ''
   const redirectUri = encodeURIComponent(window.location.origin + '/?lw_callback=1')
-  return `${apiBase}/api/auth/line/redirect?tenant_id=${orgId.value}&redirect_uri=${redirectUri}`
+  // #434 Phase 4: LINE Login は auth-worker (/oauth/line/*) を向く。
+  return `${authWorkerUrl}/oauth/line/redirect?tenant_id=${orgId.value}&redirect_uri=${redirectUri}`
 })
 
 const inviteQrCodeUrl = computed(() => {


### PR DESCRIPTION
## 概要

rust-alc-api#434 Phase 4(consumer repoint)。LINE Login の OAuth オーケストレーションが rust → auth-worker に移管された(#311 LINE WORKS engine / #312 LINE Login engine、merged)ため、nuxt-notify の LINE Login 起点を **rust(`apiBase/api/auth/line/*`)→ auth-worker(`authWorkerUrl/oauth/line/*`)** に repoint する。

## 変更

- `app/app.vue`
  - `lineLoginUrl`: `${apiBase}/api/auth/line/redirect` → `${authWorkerUrl}/oauth/line/redirect`
  - `selectTenant`: rust への `apiFetch('/auth/line/select-tenant')`(= `/api/proxy` 経由)→ **auth-worker `/oauth/line/select-tenant` への直 `$fetch`**。select-tenant は pre-login(JWT 無し)なので `/alc-proxy`(JWT 必須)を通さず public route を直接叩くのが正しい。
  - 未使用になった `useApi()` import を削除。
- `app/pages/settings.vue`
  - `inviteLoginUrl`(QR 招待): `${apiBase}/api/auth/line/redirect?tenant_id=` → `${authWorkerUrl}/oauth/line/redirect?tenant_id=`

`authWorkerUrl` は既存 `runtimeConfig.public.authWorkerUrl`。LINE WORKS は既に auth-worker 向きなので変更不要。callback の multi-tenant redirect(`?line_user_id&line_name&tenants`)/ 単一の `#token` fragment は auth-worker engine が rust と同形式で返すため、`app.vue` の既存パース(query/fragment)はそのまま動く。

## ⚠ 依存・運用

- **auth-worker(#311/#312/#313)が staging/prod に deploy 済み + LINE Developers Console の callback URI(`auth-worker/oauth/line/callback`)登録 + `line-login-channel-*` secret 投入(#313 で sync 済み)** が前提。未整備だと LINE Login が失敗する。staging で疎通確認してから prod 反映。
- **既知のセキュリティ follow-up**(別タスク): `/oauth/line/select-tenant` は body の `line_user_id` を信用する設計(rust 由来)。callback で署名済み handoff token を発行し select-tenant がそれを検証する形にハードニング予定(auth-worker + 本 front-end の協調変更)。本 PR は repoint のみで挙動は現状維持。

Refs rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_