### PR TITLE
fix: LINE select-tenant を select_token (fragment) ベースに変更 (Refs rust-alc-api#434 security)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -22,8 +22,9 @@ const loginError = ref('')
 // テナント選択 (LINE Login で複数テナントの場合)
 interface TenantOption { id: string; name: string }
 const tenantOptions = ref<TenantOption[]>([])
-const lineUserId = ref('')
-const lineName = ref('')
+const lineName = ref('') // 表示用 ("<name> さん")
+// line_user_id は署名済み select_token に封入され、front-end は中身を持たない (#434 security)。
+const selectToken = ref('')
 const selectingTenant = ref(false)
 
 async function selectTenant(tenantId: string) {
@@ -36,8 +37,7 @@ async function selectTenant(tenantId: string) {
       {
         method: 'POST',
         body: {
-          line_user_id: lineUserId.value,
-          line_name: lineName.value,
+          select_token: selectToken.value,
           tenant_id: tenantId,
         },
       },
@@ -60,6 +60,8 @@ onMounted(() => {
   // (= notify.ippoan.org への通常遷移) 場合は、auth-worker が *.ippoan.org に配る
   // logi_auth_token cookie (Domain=.ippoan.org) から復元する。recoverFromCookie を
   // 呼ばないと cookie 配布ログインを拾えず「ログインしてください」でループする。
+  // 複数テナント選択 fragment (#select_token=...) は consumeFragment が消す前に捕捉。
+  const rawHash = window.location.hash
   if (!consumeFragment()) {
     recoverFromCookie()
   }
@@ -72,13 +74,16 @@ onMounted(() => {
     loginError.value = errorParam
     window.history.replaceState({}, '', window.location.pathname)
   }
-  const tenantsParam = params.get('tenants')
-  if (tenantsParam) {
+  // 複数テナント選択は fragment (#select_token=...&line_name=...&tenants=...)。
+  // 生 line_user_id は署名済み select_token 内のみ (auth bypass / Referer leak 防止、Refs #434)。
+  const hashParams = new URLSearchParams(rawHash.replace(/^#/, ''))
+  const tenantsParam = hashParams.get('tenants')
+  const tokenParam = hashParams.get('select_token')
+  if (tenantsParam && tokenParam) {
     try {
       tenantOptions.value = JSON.parse(tenantsParam)
-      lineUserId.value = params.get('line_user_id') || ''
-      lineName.value = params.get('line_name') || ''
-      // クエリパラメータをクリア
+      selectToken.value = tokenParam
+      lineName.value = hashParams.get('line_name') || ''
       window.history.replaceState({}, '', window.location.pathname)
     } catch { /* ignore */ }
   }


### PR DESCRIPTION
## 概要

auth-worker #314(merged)の select-tenant auth bypass 修正との**協調変更**。複数テナント recipient の LINE Login 選択フローを、生 `line_user_id` ベースから **署名済み `select_token`** ベースに変更する。

## 背景

旧フローは callback が生 `line_user_id` を URL query に載せ、front-end がそれを select-tenant の body に詰めて POST していた → サーバが body の line_user_id を信用 = auth bypass。auth-worker #314 で、callback が `line_user_id` を HMAC 署名 + 10 分 TTL の `select_token` に封入し **fragment** で渡すように変更済み。

## 変更(`app/app.vue`)

- `selectTenant`: POST body を `{ line_user_id, line_name, tenant_id }` → **`{ select_token, tenant_id }`**(line_user_id を送らない)。
- `onMounted`: テナント選択パラメータを **query → fragment**(`#select_token=...&line_name=...&tenants=...`)から読む。`consumeFragment` が消す前に `rawHash` を捕捉。
- `lineUserId` ref を削除(front-end は line_user_id を一切持たない)。`lineName` は表示用(「<name> さん」)に fragment から取得。

これで front-end・URL・body のどこにも生 `line_user_id` が出ず、auth bypass / Referer leak を防止。

## ⚠ deploy 順序

auth-worker #314 が staging/prod に出てから本変更を deploy(callback が新 fragment 形式を返すため)。単一テナント / 既存ユーザー / QR 招待の主要フローは本 PR の影響なし。

Refs rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_