### PR TITLE
feat(viewer): /v ページを同一オリジン(Worker/KV)優先 + rust fallback (PR 3, Refs ippoan/rust-alc-api#434)

### DIFF
--- a/app/pages/v/[token].vue
+++ b/app/pages/v/[token].vue
@@ -80,12 +80,13 @@ async function load() {
     if (res.status === 410) { status.value = 'gone'; return }
     if (res.status === 404) { status.value = 'not_found'; return }
     if (!res.ok) { status.value = 'error'; return }
-    meta.value = await res.json()
+    const m = (await res.json()) as ViewMetadata
+    meta.value = m
     resolvedBase.value = base
     // Worker メタは content_type を含むので HEAD 不要。rust fallback は含まないので
     // 実体の Content-Type を HEAD で取る (PDF / JPEG 切替判定)。取れなければ null のまま
     // → 「ファイルを開く」ボタン (default ブランチ) に倒す。
-    const ct = meta.value.content_type
+    const ct = m.content_type
     if (ct) {
       fileContentType.value = ct.toLowerCase()
     } else {

--- a/app/pages/v/[token].vue
+++ b/app/pages/v/[token].vue
@@ -12,7 +12,14 @@ const config = useRuntimeConfig()
 const apiBase = config.public.apiBase as string
 
 const token = computed(() => String(route.params.token))
-const fileUrl = computed(() => `${apiBase}/api/notify/v/${token.value}/file`)
+
+// viewer 配信元 (#434 移行): まず同一オリジン (nuxt-notify Worker = KV+R2) を試し、
+// KV 未登録 (= #455 deploy 前の古い token) なら rust にフォールバックする。
+// '' = 同一オリジン / apiBase = rust。null = 未解決。
+const resolvedBase = ref<string | null>(null)
+const fileUrl = computed(() =>
+  resolvedBase.value === null ? '' : `${resolvedBase.value}/api/notify/v/${token.value}/file`,
+)
 
 interface ViewMetadata {
   file_name: string | null
@@ -21,6 +28,8 @@ interface ViewMetadata {
   source_sender: string | null
   source_received_at: string | null
   expire_at: string
+  // Worker (同一オリジン) のメタは content_type を含む (rust fallback は含まない)
+  content_type?: string | null
 }
 
 const meta = ref<ViewMetadata | null>(null)
@@ -60,21 +69,34 @@ function formatDate(s: string | null): string {
 
 async function load() {
   try {
-    const res = await fetch(`${apiBase}/api/notify/v/${token.value}`)
+    // 同一オリジン (Worker/KV) を優先。404 (KV 未登録) / 503 (binding 未設定) は
+    // rust にフォールバック。410 (失効) / その他はそのまま扱う。
+    let base = ''
+    let res = await fetch(`/api/notify/v/${token.value}`)
+    if (res.status === 404 || res.status === 503) {
+      base = apiBase
+      res = await fetch(`${apiBase}/api/notify/v/${token.value}`)
+    }
     if (res.status === 410) { status.value = 'gone'; return }
     if (res.status === 404) { status.value = 'not_found'; return }
     if (!res.ok) { status.value = 'error'; return }
     meta.value = await res.json()
-    // 並行で実体の Content-Type を HEAD で取る (PDF / JPEG 切替判定)。
-    // HEAD が失敗したり Content-Type が不明だったら fileContentType=null のまま
+    resolvedBase.value = base
+    // Worker メタは content_type を含むので HEAD 不要。rust fallback は含まないので
+    // 実体の Content-Type を HEAD で取る (PDF / JPEG 切替判定)。取れなければ null のまま
     // → 「ファイルを開く」ボタン (default ブランチ) に倒す。
-    try {
-      const head = await fetch(fileUrl.value, { method: 'HEAD' })
-      if (head.ok) {
-        fileContentType.value = head.headers.get('content-type')?.toLowerCase() ?? null
+    const ct = meta.value.content_type
+    if (ct) {
+      fileContentType.value = ct.toLowerCase()
+    } else {
+      try {
+        const head = await fetch(fileUrl.value, { method: 'HEAD' })
+        if (head.ok) {
+          fileContentType.value = head.headers.get('content-type')?.toLowerCase() ?? null
+        }
+      } catch {
+        // ignore — file-name ベース推測はしない (古い情報の方が有害)
       }
-    } catch {
-      // ignore — fallback to file-name based detection はしない (古い情報の方が有害)
     }
     status.value = 'ok'
   } catch {


### PR DESCRIPTION
## 概要

#434 viewer 移行 **PR 3**。公開 viewer ページ `/v/[token]` の配信元を、まず**同一オリジン (nuxt-notify Worker = KV+R2、#99)** に取りに行き、**KV 未登録なら rust にフォールバック**する。

これで register 済み (rust#455 deploy 後の) token は Worker/KV/R2 経由で配信され、`#455` deploy 前の古い token は従来どおり rust 配信される。**非破壊**。

## なぜ fallback が要るか

`/v/[token]` ページは message リンク (rust `/read` → 302) から到達する。`#455` deploy **前**に配信された token は KV に無いため、単純切替だと 404 になる。リンク TTL は 7 日なので、移行窓 (約 7 日) を過ぎれば全ライブ token が KV に乗り、その後 lockdown で rust public 撤去できる。

## 変更点 (`app/pages/v/[token].vue`)

- 配信元を解決 base (`''` = 同一オリジン / `apiBase` = rust) ベースに変更
- `load()`: 同一オリジン `/api/notify/v/{token}` を試し、**404 (KV 未登録) / 503 (binding 未設定) のみ** rust にフォールバック。410 (失効) / 404 / error はそのまま
- `fileUrl` も解決 base から組み立て（PDF.js / 画像 / DL リンクが正しいオリジンを指す）
- Worker メタは `content_type` を含むので **HEAD 省略**、rust fallback 時のみ従来の HEAD で content-type 判定

## スコープ外 (後続)

- read-tracking はまだ rust `/read` のまま（message URL の Worker repoint / 管理画面「既読」の KV 化は後続 PR）
- lockdown cutover (旧 public `/api/notify/v/*` `/read/*` 撤去 + `allUsers` 削除)

Refs ippoan/rust-alc-api#434

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRVaeXY89DuETaakvY5HW7)_