### PR TITLE
feat(viewer): 管理画面の既読を KV (tenant scope) からマージ表示 (PR 5, Refs ippoan/rust-alc-api#434)

### DIFF
--- a/app/pages/documents/[id].vue
+++ b/app/pages/documents/[id].vue
@@ -74,6 +74,9 @@ interface DocumentResponse {
 
 const document = ref<NotifyDocument | null>(null)
 const deliveries = ref<Delivery[]>([])
+// viewer Worker が KV に記録した既読 (recipient_id → read_at)。lockdown 移行後の既読は
+// rust DB ではなく KV に入るため、rust の read_at とマージ表示する (Refs #434)。
+const kvReads = ref<Record<string, string>>({})
 const loading = ref(true)
 const error = ref('')
 const showDistribute = ref(false)
@@ -224,6 +227,7 @@ async function load() {
     const res = await apiFetch<DocumentResponse>(`/notify/documents/${documentId.value}`)
     document.value = res.document
     deliveries.value = res.deliveries
+    void loadReadStatus()
     // processing 中は 5 秒後に再取得 (UI が「処理中」のまま固まらないように)
     schedulePollIfProcessing()
   } catch (e: any) {
@@ -231,6 +235,25 @@ async function load() {
   } finally {
     loading.value = false
   }
+}
+
+// KV の既読を取得 (best-effort、同一オリジンの read-status route = requireAuth で
+// tenant scope)。失敗しても既読列が '-' になるだけで致命ではない。
+async function loadReadStatus() {
+  try {
+    const res = await fetch(`/api/notify/read-status/${documentId.value}`)
+    if (res.ok) {
+      const data = (await res.json()) as { reads: Record<string, string> }
+      kvReads.value = data.reads ?? {}
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// rust DB の read_at と KV の既読をマージ (どちらかにあれば既読)。
+function readAtOf(d: Delivery): string | null {
+  return d.read_at ?? kvReads.value[d.recipient_id] ?? null
 }
 
 function schedulePollIfProcessing() {
@@ -847,7 +870,7 @@ onUnmounted(() => {
                   {{ deliveryStatusLabel(d.status).label }}
                 </span>
               </td>
-              <td class="py-1 text-gray-500">{{ d.read_at ? formatDate(d.read_at) : '-' }}</td>
+              <td class="py-1 text-gray-500">{{ readAtOf(d) ? formatDate(readAtOf(d)!) : '-' }}</td>
             </tr>
           </tbody>
         </table>

--- a/app/pages/emails/[id].vue
+++ b/app/pages/emails/[id].vue
@@ -49,6 +49,9 @@ interface DocumentResponse {
 
 const detail = ref<EmailDetail | null>(null)
 const deliveriesByDoc = ref<Record<string, Delivery[]>>({})
+// viewer Worker が KV に記録した既読 (docId → recipient_id → read_at)。lockdown 移行後の
+// 既読は rust DB ではなく KV に入るため rust の read_at とマージ表示する (Refs #434)。
+const kvReadsByDoc = ref<Record<string, Record<string, string>>>({})
 const loading = ref(true)
 const error = ref('')
 const deleting = ref<Record<string, boolean>>({})
@@ -71,9 +74,28 @@ async function loadDeliveries(doc: EmailDocument) {
   try {
     const res = await apiFetch<DocumentResponse>(`/notify/documents/${doc.id}`)
     deliveriesByDoc.value[doc.id] = res.deliveries
+    void loadReadStatus(doc.id)
   } catch {
     deliveriesByDoc.value[doc.id] = []
   }
+}
+
+// KV の既読を doc 単位で取得 (best-effort、同一オリジン read-status = requireAuth で tenant scope)。
+async function loadReadStatus(docId: string) {
+  try {
+    const res = await fetch(`/api/notify/read-status/${docId}`)
+    if (res.ok) {
+      const data = (await res.json()) as { reads: Record<string, string> }
+      kvReadsByDoc.value[docId] = data.reads ?? {}
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// rust DB の read_at と KV の既読をマージ (どちらかにあれば既読)。
+function readAtOf(docId: string, d: Delivery): string | null {
+  return d.read_at ?? kvReadsByDoc.value[docId]?.[d.recipient_id] ?? null
 }
 
 async function downloadDoc(doc: EmailDocument) {
@@ -203,7 +225,7 @@ onMounted(loadDetail)
                     {{ deliveryStatusLabel(d.status).label }}
                   </span>
                 </td>
-                <td class="py-1 text-gray-500">{{ d.read_at ? formatDate(d.read_at) : '-' }}</td>
+                <td class="py-1 text-gray-500">{{ readAtOf(doc.id, d) ? formatDate(readAtOf(doc.id, d)!) : '-' }}</td>
               </tr>
             </tbody>
           </table>

--- a/server/api/notify/read-status/[documentId].get.ts
+++ b/server/api/notify/read-status/[documentId].get.ts
@@ -1,0 +1,75 @@
+/**
+ * GET /api/notify/read-status/{documentId}  (管理画面用、要認証)
+ *
+ * viewer Worker が記録した既読 (`read:{tenant_id}:{document_id}:{recipient_id}`) を
+ * document 単位で返す。`requireAuth` (auth-worker introspect) で認証し、その `tenant_id`
+ * で KV prefix を絞る = **サーバ側でテナント分離** (document_id の秘匿に頼らない)。
+ *
+ * 返り値: `{ reads: { [recipient_id]: read_at(ISO) } }`
+ */
+import type { H3Event } from 'h3'
+import { requireAuth } from '@ippoan/auth-client/server'
+import { readKeyPrefix, type ReadRecord } from '../../../utils/notify-view'
+
+function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}
+
+interface KvListKey {
+  name: string
+}
+interface KvNamespace {
+  get(key: string): Promise<string | null>
+  list(options: { prefix: string; cursor?: string }): Promise<{
+    keys: KvListKey[]
+    list_complete: boolean
+    cursor?: string
+  }>
+}
+
+export default defineEventHandler(async (event) => {
+  const env = cfEnv(event)
+  const kv = env.NOTIFY_VIEW_KV as KvNamespace | undefined
+  if (!kv) {
+    throw createError({ statusCode: 503, statusMessage: 'NOTIFY_VIEW_KV binding 未設定' })
+  }
+
+  // 認証 (introspect)。active なら tenant_id が取れる。inactive は 401 throw。
+  const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+  if (!sharedSecret) {
+    throw createError({ statusCode: 503, statusMessage: 'INTERNAL_SHARED_SECRET binding 未設定' })
+  }
+  const cfg = useRuntimeConfig(event)
+  const auth = await requireAuth(event, {
+    authWorkerUrl: cfg.public.authWorkerUrl as string,
+    sharedSecret,
+  })
+
+  const documentId = getRouterParam(event, 'documentId') ?? ''
+  const prefix = readKeyPrefix(auth.tenant_id, documentId)
+
+  const reads: Record<string, string> = {}
+  let cursor: string | undefined
+  // prefix list (1000件/ページ)。受信者数は通常少数なので 1〜数ページで完了。
+  do {
+    const page = await kv.list({ prefix, cursor })
+    for (const k of page.keys) {
+      const raw = await kv.get(k.name)
+      if (raw) {
+        const r = JSON.parse(raw) as ReadRecord
+        reads[r.recipient_id] = r.read_at
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor
+  } while (cursor)
+
+  return { reads }
+})

--- a/server/api/notify/v/[token].get.ts
+++ b/server/api/notify/v/[token].get.ts
@@ -46,8 +46,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 410, statusMessage: 'gone' })
   }
 
-  // 既読記録 (恒久)。初回閲覧時刻を保つため、既存があれば上書きしない。
-  const rkey = readKey(rec.document_id, rec.recipient_id)
+  // 既読記録 (恒久、tenant×doc×recipient キー)。初回閲覧時刻を保つため上書きしない。
+  const rkey = readKey(rec.tenant_id, rec.document_id, rec.recipient_id)
   const existing = await kv.get(rkey)
   if (!existing) {
     const read: ReadRecord = {

--- a/server/utils/notify-view.ts
+++ b/server/utils/notify-view.ts
@@ -3,8 +3,9 @@
  *
  * 設計 (Refs ippoan/rust-alc-api#434):
  * - `view:{token}` … r2_key + メタ。**TTL = リンク失効**。配信用、使い捨て
- * - `read:{document_id}:{recipient_id}` … 既読。**TTL なし = 恒久**。file キーなので
- *   token (view) 失効と無関係に既読履歴が残る
+ * - `read:{tenant_id}:{document_id}:{recipient_id}` … 既読。**TTL なし = 恒久**。
+ *   file (tenant×doc×recipient) キーなので token (view) 失効と無関係に既読履歴が残り、
+ *   tenant prefix でサーバ側テナント分離できる
  *
  * runtime で rust/auth-worker を呼ばない。rust は distribute 時に register endpoint
  * 経由で `view:{token}` を書くだけ。
@@ -15,6 +16,7 @@
 /** KV に格納する view レコード (配信用、TTL あり)。 */
 export interface ViewRecord {
   r2_key: string
+  tenant_id: string
   document_id: string
   recipient_id: string
   file_name: string | null
@@ -46,13 +48,14 @@ export function viewKey(token: string): string {
   return `view:${token}`
 }
 
-export function readKey(documentId: string, recipientId: string): string {
-  return `read:${documentId}:${recipientId}`
+export function readKey(tenantId: string, documentId: string, recipientId: string): string {
+  return `read:${tenantId}:${documentId}:${recipientId}`
 }
 
-/** read:{document_id}: prefix (管理画面が document 単位で既読を list する用)。 */
-export function readKeyPrefix(documentId: string): string {
-  return `read:${documentId}:`
+/** read:{tenant_id}:{document_id}: prefix (管理画面が tenant scope で document 単位の
+ *  既読を list する用。KV multi-tenant の定石 = tenant prefix でサーバ側分離)。 */
+export function readKeyPrefix(tenantId: string, documentId: string): string {
+  return `read:${tenantId}:${documentId}:`
 }
 
 /**
@@ -64,12 +67,14 @@ export function parseRegisterBody(body: unknown): ViewRecord | null {
   const b = body as Record<string, unknown>
   const str = (v: unknown): string | null => (typeof v === 'string' && v.length > 0 ? v : null)
   const r2_key = str(b.r2_key)
+  const tenant_id = str(b.tenant_id)
   const document_id = str(b.document_id)
   const recipient_id = str(b.recipient_id)
   const expire_at = str(b.expire_at)
-  if (!r2_key || !document_id || !recipient_id || !expire_at) return null
+  if (!r2_key || !tenant_id || !document_id || !recipient_id || !expire_at) return null
   return {
     r2_key,
+    tenant_id,
     document_id,
     recipient_id,
     file_name: typeof b.file_name === 'string' ? b.file_name : null,

--- a/tests/server/notify-view-routes.test.ts
+++ b/tests/server/notify-view-routes.test.ts
@@ -18,13 +18,29 @@ const { createErrorMock, headers, routerParams, bodyRef, setHeaderMock } = vi.ho
   ;(globalThis as Record<string, unknown>).readBody = async () => bodyRef.value
   const setHeaderMock = vi.fn()
   ;(globalThis as Record<string, unknown>).setResponseHeader = setHeaderMock
+  // read-status route が使う Nitro グローバル。
+  ;(globalThis as Record<string, unknown>).useRuntimeConfig = () => ({
+    public: { authWorkerUrl: 'https://auth.example' },
+  })
   return { createErrorMock, headers, routerParams, bodyRef, setHeaderMock }
 })
+
+// read-status は requireAuth (introspect) で tenant_id を得る。テストでは固定 tenant に mock。
+vi.mock('@ippoan/auth-client/server', () => ({
+  requireAuth: vi.fn(async () => ({
+    active: true,
+    tenant_id: 'tn-1',
+    role: 'admin',
+    email: 'a@example.com',
+    sub: 'u-1',
+  })),
+}))
 
 import registerView from '../../server/api/notify/register-view.post'
 import viewMeta from '../../server/api/notify/v/[token].get'
 import viewFile from '../../server/api/notify/v/[token]/file.get'
 import viewImage from '../../server/api/notify/v/[token]/image.jpg.get'
+import readStatus from '../../server/api/notify/read-status/[documentId].get'
 
 const call = (h: unknown, e: unknown) => (h as (e: unknown) => Promise<unknown>)(e)
 const eventWith = (env: Record<string, unknown>) => ({ context: { cloudflare: { env } } })
@@ -35,6 +51,10 @@ function fakeKv(initial: Record<string, string> = {}) {
     store,
     put: vi.fn(async (k: string, v: string) => { store.set(k, v) }),
     get: vi.fn(async (k: string) => store.get(k) ?? null),
+    list: vi.fn(async ({ prefix }: { prefix: string; cursor?: string }) => ({
+      keys: [...store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name })),
+      list_complete: true as const,
+    })),
   }
 }
 function fakeR2(objects: Record<string, Uint8Array> = {}) {
@@ -50,6 +70,7 @@ const past = '2000-01-01T00:00:00.000Z'
 function viewRec(over: Record<string, unknown> = {}) {
   return JSON.stringify({
     r2_key: 'tenant/m/file.pdf',
+    tenant_id: 'tn-1',
     document_id: 'doc-1',
     recipient_id: 'rcp-1',
     file_name: 'file.pdf',
@@ -100,7 +121,7 @@ describe('register-view', () => {
   })
   it('正常は KV に view:{token} を put', async () => {
     headers['x-notify-internal-secret'] = 'right'
-    bodyRef.value = { token: 'tok', r2_key: 'k', document_id: 'd', recipient_id: 'r', expire_at: future }
+    bodyRef.value = { token: 'tok', tenant_id: 'tn', r2_key: 'k', document_id: 'd', recipient_id: 'r', expire_at: future }
     const kv = fakeKv()
     const res = await call(registerView, eventWith({ INTERNAL_SHARED_SECRET: 'right', NOTIFY_VIEW_KV: kv }))
     expect(res).toEqual({ ok: true })
@@ -131,17 +152,17 @@ describe('GET /v/{token} metadata', () => {
     expect(res.content_type).toBe('application/pdf')
     expect(res.file_name).toBe('file.pdf')
     expect(JSON.stringify(res)).not.toContain('r2_key')
-    // 既読 read:doc-1:rcp-1 が書かれる
-    expect(kv.store.has('read:doc-1:rcp-1')).toBe(true)
+    // 既読 read:{tenant}:doc-1:rcp-1 が書かれる (tenant prefix)
+    expect(kv.store.has('read:tn-1:doc-1:rcp-1')).toBe(true)
   })
   it('既読が既存なら上書きしない', async () => {
     routerParams.token = 'tok'
     const kv = fakeKv({
       'view:tok': viewRec(),
-      'read:doc-1:rcp-1': JSON.stringify({ read_at: 'orig', recipient_id: 'rcp-1' }),
+      'read:tn-1:doc-1:rcp-1': JSON.stringify({ read_at: 'orig', recipient_id: 'rcp-1' }),
     })
     await call(viewMeta, eventWith({ NOTIFY_VIEW_KV: kv }))
-    expect(JSON.parse(kv.store.get('read:doc-1:rcp-1')!).read_at).toBe('orig')
+    expect(JSON.parse(kv.store.get('read:tn-1:doc-1:rcp-1')!).read_at).toBe('orig')
   })
 })
 
@@ -199,5 +220,31 @@ describe('GET /v/{token}/image.jpg', () => {
     const res = (await call(viewImage, eventWith({ NOTIFY_VIEW_KV: kv, NOTIFY_R2: r2 }))) as Uint8Array
     expect(Array.from(res)).toEqual([9])
     expect(setHeaderMock).toHaveBeenCalledWith(expect.anything(), 'content-type', 'image/jpeg')
+  })
+})
+
+describe('GET /read-status/{documentId}', () => {
+  it('KV 未設定は 503', async () => {
+    routerParams.documentId = 'doc-1'
+    await expectStatus(call(readStatus, eventWith({})), 503)
+  })
+  it('INTERNAL_SHARED_SECRET 未設定は 503', async () => {
+    routerParams.documentId = 'doc-1'
+    await expectStatus(call(readStatus, eventWith({ NOTIFY_VIEW_KV: fakeKv() })), 503)
+  })
+  it('tenant scope で reads を返す (別 tenant の read は除外)', async () => {
+    routerParams.documentId = 'doc-1'
+    const kv = fakeKv({
+      'read:tn-1:doc-1:rcp-1': JSON.stringify({ read_at: 't1', recipient_id: 'rcp-1' }),
+      'read:tn-1:doc-1:rcp-2': JSON.stringify({ read_at: 't2', recipient_id: 'rcp-2' }),
+      // 別 tenant / 別 doc は prefix 外なので返らない
+      'read:tn-OTHER:doc-1:rcp-9': JSON.stringify({ read_at: 'x', recipient_id: 'rcp-9' }),
+      'read:tn-1:doc-2:rcp-3': JSON.stringify({ read_at: 'y', recipient_id: 'rcp-3' }),
+    })
+    const res = (await call(
+      readStatus,
+      eventWith({ NOTIFY_VIEW_KV: kv, INTERNAL_SHARED_SECRET: 'sek' }),
+    )) as { reads: Record<string, string> }
+    expect(res.reads).toEqual({ 'rcp-1': 't1', 'rcp-2': 't2' })
   })
 })

--- a/tests/server/notify-view.test.ts
+++ b/tests/server/notify-view.test.ts
@@ -18,6 +18,7 @@ import {
 
 const sample = (): ViewRecord => ({
   r2_key: 'tenant/email/msg/file.pdf',
+  tenant_id: 'tn-1',
   document_id: 'doc-1',
   recipient_id: 'rcp-1',
   file_name: 'file.pdf',
@@ -31,8 +32,8 @@ const sample = (): ViewRecord => ({
 describe('keys', () => {
   it('viewKey / readKey / readKeyPrefix', () => {
     expect(viewKey('abc')).toBe('view:abc')
-    expect(readKey('doc-1', 'rcp-1')).toBe('read:doc-1:rcp-1')
-    expect(readKeyPrefix('doc-1')).toBe('read:doc-1:')
+    expect(readKey('tn-1', 'doc-1', 'rcp-1')).toBe('read:tn-1:doc-1:rcp-1')
+    expect(readKeyPrefix('tn-1', 'doc-1')).toBe('read:tn-1:doc-1:')
   })
 })
 
@@ -41,6 +42,7 @@ describe('parseRegisterBody', () => {
     const rec = parseRegisterBody({ token: 't', ...sample() })
     expect(rec).not.toBeNull()
     expect(rec!.r2_key).toBe('tenant/email/msg/file.pdf')
+    expect(rec!.tenant_id).toBe('tn-1')
     expect(rec!.file_size_bytes).toBe(2048)
   })
 
@@ -48,13 +50,15 @@ describe('parseRegisterBody', () => {
     expect(parseRegisterBody(null)).toBeNull()
     expect(parseRegisterBody('x')).toBeNull()
     expect(parseRegisterBody({})).toBeNull()
-    expect(parseRegisterBody({ r2_key: 'k', document_id: 'd', recipient_id: 'r' })).toBeNull() // expire_at 欠落
-    expect(parseRegisterBody({ r2_key: '', document_id: 'd', recipient_id: 'r', expire_at: 'e' })).toBeNull() // 空文字
+    expect(parseRegisterBody({ r2_key: 'k', tenant_id: 't', document_id: 'd', recipient_id: 'r' })).toBeNull() // expire_at 欠落
+    expect(parseRegisterBody({ r2_key: 'k', document_id: 'd', recipient_id: 'r', expire_at: 'e' })).toBeNull() // tenant_id 欠落
+    expect(parseRegisterBody({ r2_key: '', tenant_id: 't', document_id: 'd', recipient_id: 'r', expire_at: 'e' })).toBeNull() // 空文字
   })
 
   it('optional は型不一致なら null フィールドに落とす', () => {
     const rec = parseRegisterBody({
       r2_key: 'k',
+      tenant_id: 't',
       document_id: 'd',
       recipient_id: 'r',
       expire_at: 'e',


### PR DESCRIPTION
## 概要

#434 viewer 移行の **管理画面側 cutover**。配信リンクが Worker `/v` に向いた後（rust #456）、既読は rust DB ではなく **KV (`read:{tenant_id}:{document_id}:{recipient_id}`)** に記録される。管理画面がこれを読めるようにし、rust `read_at` と**マージ表示**する（移行期はどちらかにあれば既読）。

read キーは **tenant 前置**にしてサーバ側でテナント分離する（KV multi-tenant の定石。`document_id` の秘匿に頼らない。rust #457 が `tenant_id` を register に載せる）。

## 変更点

- `server/utils/notify-view.ts`:
  - `ViewRecord` / `parseRegisterBody` に **`tenant_id` 必須化**（rust #457 が送る）
  - `readKey(tenantId, documentId, recipientId)` → `read:{tenant}:{doc}:{rcp}`、`readKeyPrefix(tenantId, documentId)`
- `server/api/notify/v/[token].get.ts`: 既読書き込みを tenant 前置キーに
- **新規** `server/api/notify/read-status/[documentId].get.ts`: `requireAuth`（auth-worker introspect）の `tenant_id` で KV prefix を絞り `{ reads: { [recipient_id]: read_at } }` を返す（**サーバ側でテナント分離**）
- `documents/[id].vue` / `emails/[id].vue`: read-status を best-effort fetch し rust `read_at` とマージ（`readAtOf`）
- tests 更新（tenant 込み）

## 設計根拠

web 調査で確認: KV multi-tenant は **tenant prefix キー**が定石（「テナントフィルタ無しのクエリ 1 つで漏洩」）。requireAuth で認証 + `tenant_id` 強制でクロステナント参照を構造的に防ぐ。

## 後続

- lockdown cutover: 旧 public rust `/api/notify/v/*` `/read/*` 撤去 + `allUsers` 削除（viewer 移行はこの PR で機能的に完了。lockdown は別タスク）

Refs ippoan/rust-alc-api#434

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRVaeXY89DuETaakvY5HW7)_