### PR TITLE
chore(deps): @ippoan/auth-client を ^0.2.105 へ (login ループ #377 取込, Refs ippoan/auth-worker#379)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "^0.2.78",
+    "@ippoan/auth-client": "^0.2.105",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.4.2",
     "vue": "^3.5.31",


### PR DESCRIPTION
## 概要

auth-worker #377 (毒 cookie で戻ったら reauth = login ループ回避) を含む `@ippoan/auth-client@0.2.105` を floor に指定する。

## 背景

2026-07-13 の login 無限ループ障害の根本修正が #377 (auth-client) / #376 (auth-worker `/top`) で入ったが、本アプリは #377 publish (0.2.105) より前の版で最終デプロイされており未反映。本 PR の commit を trigger に再デプロイし #377 を取り込む。

## 変更

- `package.json`: `@ippoan/auth-client` を `^0.2.105` に更新
- lockfile は caller の `install_command: npm install` で再解決される (Packages token 不要)

Refs ippoan/auth-worker#379, ippoan/auth-worker#377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkS7MFMf5zLWaBF3kU5Hv8)_